### PR TITLE
[CLUST-18] Add backend CI workflow, make file, and getting started guide

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Lint, Test, and Build Backend
 
 on:
   push:
-    branches-ignore:
+    branches:
       - main
 
 jobs:
@@ -15,7 +15,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-            go-version: '1.24'
+          go-version: '1.24'
 
       - name: Lint
         uses: golangci/golangci-lint-action@v7
@@ -23,6 +23,7 @@ jobs:
           version: v2.0
 
   Test:
+    needs: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -56,7 +57,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-            go-version: '1.24'
+          go-version: '1.24'
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
@@ -66,7 +67,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-            mockery-version: '2.53.3'
+          mockery-version: '2.53.3'
 
       - name: Build
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,9 +1,9 @@
 name: Lint, Test, and Build Backend
 
 on:
-  push:
-    branches-ignore:
-      - main
+    pull_request:
+        branches:
+        - main
 
 jobs:
   Lint:
@@ -15,7 +15,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-            go-version: '1.24'
+          go-version: '1.24'
 
       - name: Lint
         uses: golangci/golangci-lint-action@v7
@@ -56,7 +56,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-            go-version: '1.24'
+          go-version: '1.24'
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
@@ -66,7 +66,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-            mockery-version: '2.53.3'
+          mockery-version: '2.53.3'
 
       - name: Build
         run: |

--- a/.github/workflows/push-commit.yaml
+++ b/.github/workflows/push-commit.yaml
@@ -1,0 +1,81 @@
+name: Lint, Test, and Build Backend
+
+on: push
+
+jobs:
+  Lint:
+    runs-on:  ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+            go-version: '1.24'
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.0
+
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Setup Sqlc
+        uses: sqlc-dev/setup-sqlc@v4
+        with:
+          sqlc-version: '1.25.0'
+
+      - name: Setup mockery
+        uses: brokeyourbike/go-mockery-action@v0
+        with:
+          mockery-version: '2.53.3'
+
+      - name: Test
+        run: make test
+
+  Build:
+    needs: Test
+    runs-on:  ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+            go-version: '1.24'
+
+      - name: Setup Sqlc
+        uses: sqlc-dev/setup-sqlc@v4
+        with:
+          sqlc-version: '1.25.0'
+
+      - name: Setup mockery
+        uses: brokeyourbike/go-mockery-action@v0
+        with:
+            mockery-version: '2.53.3'
+
+      - name: Build
+        run: |
+          go mod download
+          make build
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --tag myusername/backend:${{ github.sha }} \
+            --file Dockerfile \

--- a/.github/workflows/push-commit.yml
+++ b/.github/workflows/push-commit.yml
@@ -15,9 +15,9 @@ jobs:
             go-version: '1.24'
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.0
+          version: v2.0
 
   Test:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-commit.yml
+++ b/.github/workflows/push-commit.yml
@@ -6,7 +6,28 @@ on:
       - main
 
 jobs:
+  check-if-in-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      in_pr: ${{ steps.check.outputs.result }}
+    steps:
+      - name: Check if branch is part of an open PR
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open'
+            });
+            return prs.data.length > 0;
+
   Lint:
+    needs: check-if-in-pr
+    if: needs.check-if-in-pr.outputs.in_pr == 'false'
     runs-on:  ubuntu-latest
     steps:
       - name: Checkout source
@@ -23,6 +44,8 @@ jobs:
           version: v2.0
 
   Test:
+    needs: check-if-in-pr
+    if: needs.check-if-in-pr.outputs.in_pr == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -47,7 +70,8 @@ jobs:
         run: make test
 
   Build:
-    needs: Test
+    needs: [check-if-in-pr, Test]
+    if: needs.check-if-in-pr.outputs.in_pr == 'false'
     runs-on:  ubuntu-latest
     steps:
       - name: Checkout source

--- a/.github/workflows/push-commit.yml
+++ b/.github/workflows/push-commit.yml
@@ -79,3 +79,4 @@ jobs:
             --platform linux/amd64 \
             --tag myusername/backend:${{ github.sha }} \
             --file Dockerfile \
+            .

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.24
+
+WORKDIR ./app
+
+COPY . .
+
+RUN go mod tidy && go build -o bin/backend ./cmd/backend/main.go
+
+EXPOSE 8080
+
+CMD ["./backend"]

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ prepare:
 	@echo -e ":: $(GREEN) Preparing environment...$(NC)"
 	@echo -e ":: $(GREEN) Downloading go dependencies...$(NC)"
 	@go mod download \
-		&& echo -e ":: $(BLUE) Successfully downloaded go dependencies$(NC)" \
-		|| (echo -e ":: $(RED) Failed to download go dependencies$(NC)" && exit 1)
+		&& echo -e "==> $(BLUE) Successfully downloaded go dependencies$(NC)" \
+		|| (echo -e "==> $(RED) Failed to download go dependencies$(NC)" && exit 1)
 
 run:
 	@echo -e ":: $(GREEN)Starting backend...$(NC)"
 	@go build -o bin/backend cmd/backend/main.go && \
 		DEBUG=true ./bin/backend \
-		&& echo -e "==> &(BLUE)Successfully shout down backend$(NC)" \
+		&& echo -e "==> $(BLUE)Successfully shout down backend$(NC)" \
 		|| (echo -e "==> $(RED)Backend failed to start $(NC)" && exit 1)
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+GREEN = \033[0;32m
+BLUE = \033[0;34m
+RED = \033[0;31m
+NC = \033[0m
+
+all: build
+
+run:
+	@echo -e ":: $(GREEN)Starting backend...$(NC)"
+	@go build -o bin/backend cmd/backend/main.go && \
+		DEBUG=true ./bin/backend \
+		&& echo -e "==> &(BLUE)Successfully shout down backend$(NC)" \
+		|| (echo -e "==> $(RED)Backend failed to start $(NC)" && exit 1)
+
+build:
+	@echo -e ":: $(GREEN)Building backend...$(NC)"
+	@echo -e "  -> Building backend binary..."
+	@go build -o bin/backend cmd/backend/main.go && echo -e "==> $(BLUE)Build completed successfully$(NC)" || (echo -e "==> $(RED)Build failed$(NC)" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ NC = \033[0m
 
 all: build
 
+prepare:
+	@echo -e ":: $(GREEN) Preparing environment...$(NC)"
+	@echo -e ":: $(GREEN) Downloading go dependencies...$(NC)"
+	@go mod download \
+		&& echo -e ":: $(BLUE) Successfully downloaded go dependencies$(NC)" \
+		|| (echo -e ":: $(RED) Failed to download go dependencies$(NC)" && exit 1)
+
 run:
 	@echo -e ":: $(GREEN)Starting backend...$(NC)"
 	@go build -o bin/backend cmd/backend/main.go && \

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,7 @@ build:
 	@echo -e ":: $(GREEN)Building backend...$(NC)"
 	@echo -e "  -> Building backend binary..."
 	@go build -o bin/backend cmd/backend/main.go && echo -e "==> $(BLUE)Build completed successfully$(NC)" || (echo -e "==> $(RED)Build failed$(NC)" && exit 1)
+
+test:
+	@echo -e ":: $(GREEN)Running tests...$(NC)"
+	@go test -cover ./... && echo -e "==> $(BLUE)All tests passed$(NC)" || echo -e "==> $(RED)Tests failed$(NC)"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 go install github.com/vektra/mockery/v3@v3.2.2      # not recommanded by the documentation
 ```
 
-You can also find more OS-spacific installing methods from to documentation.
+You can also find more OS-spacific installing methods from the documentation.
 
 ## Run the backend
 You can simply start the backend service via command:
@@ -59,3 +59,38 @@ To build the backend code into binary, run:
 make build
 ```
 The binary file will be `./bin/backend`.
+
+## Pre-push hook (Optional)
+We recommand you enable the pre-push hook if wish to commit to this repository.
+This will run checks before the code is pushed to the remote.
+
+The pre-push hook is run via [lefthook](https://lefthook.dev).
+
+### MacOS
+```
+brew install lefthook
+```
+### Go install 
+```
+go install github.com/evilmartians/lefthook@latest
+```
+You can also find more OS-spacific installing methods from the documentation.
+
+After installed lefthook, update git hook to use lefthook:
+```
+# run at project root
+left hook install
+```
+Then you are good to go!
+The pre-push checks will be envoked when you do `git push`.
+
+If the checks didn't pass, the push will be blocked.
+
+To temporary by pass the pre-push check and push:
+```
+git push origin --no-verify
+```
+To disable pre-push action until re-open it:
+```
+left hook uninstall
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # clustron-backend
+This is the backend of NYCU SDC Clustron Project. 
+
+We aim to create a service to visuallize the LDAP access managing, Slurm operation, and resource usage on remote computer cluster.
+
+# Get Started
+## Install Go
+Follow the [official installation guide](https://go.dev/doc/install).
+Choose version 1.24 if you would like to specify the Go version.
+
+## Clone the repository
+Open your terminal and navigate to the directory that you wish to put this project.
+
+And then execute the following command: 
+```
+git clone https://github.com/NYCU-SDC/clustron-backend.git
+cd  clustron-backend
+git fetch
+```
+
+## Install necessary dependencies
+### Install Go packages
+```
+make prepare
+```
+Be sure you have `make` installed. You can check by:
+```
+make -v
+```
+If the result is something like `make command not found`, install `make` before running the above command.
+
+### Install other tools
+We use [sqlc](https://sqlc.dev) for database query generation and [mockery](https://vektra.github.io/mockery/latest/) for mocking.
+
+#### MacOS
+```
+brew install sqlc
+
+brew install mockery
+brew upgrade mockery
+```
+#### Go install 
+```
+go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+go install github.com/vektra/mockery/v3@v3.2.2      # not recommanded by the documentation
+```
+
+You can also find more OS-spacific installing methods from to documentation.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,16 @@ go install github.com/vektra/mockery/v3@v3.2.2      # not recommanded by the doc
 ```
 
 You can also find more OS-spacific installing methods from to documentation.
+
+## Run the backend
+You can simply start the backend service via command:
+```
+make run
+```
+
+## Build the backend
+To build the backend code into binary, run:
+```
+make build
+```
+The binary file will be `./bin/backend`.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+#   Refer for explanation to following link:
+#   https://lefthook.dev/configuration/
+pre-push:
+  commands:
+    lint:
+      run: golangci-lint run


### PR DESCRIPTION
# Type of change
- CI
- Feature

# Purpose
- Add backend CI workflow to run lint, unit test, and build to ensure the program works. The workflow will run on every push.
- Add Makefile to wrap up, prepare, run, test, and build script for easy start-up of the project.
- Add a getting started guide in README to indicate the necessary dependency to run the project and the usage of the Makefile commands.

# Additional information
- The prepare script only installs go package dependencies that are installed via go get. For those tools that have different import methods via different package managers and OS, we recommend the readers find the preferred method from the official documentation.