### PR TITLE
[CLUST-19] Switch workflow runner to self-hosted runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Lint:
-    runs-on:  ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
 
   Test:
     needs: Lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
 
   Build:
     needs: Test
-    runs-on:  ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Lint:
-    runs-on:  ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
           version: v2.0
 
   Test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
 
   Build:
     needs: Test
-    runs-on:  ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/push-commit.yml
+++ b/.github/workflows/push-commit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-if-in-pr:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       in_pr: ${{ steps.check.outputs.result }}
     steps:
@@ -28,7 +28,7 @@ jobs:
   Lint:
     needs: check-if-in-pr
     if: needs.check-if-in-pr.outputs.in_pr == 'false'
-    runs-on:  ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
   Test:
     needs: check-if-in-pr
     if: needs.check-if-in-pr.outputs.in_pr == 'false'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
   Build:
     needs: [check-if-in-pr, Test]
     if: needs.check-if-in-pr.outputs.in_pr == 'false'
-    runs-on:  ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/TESTFILE
+++ b/TESTFILE
@@ -1,0 +1,1 @@
+This is used to test the self-hosted runner if works properly.

--- a/TESTFILE
+++ b/TESTFILE
@@ -1,1 +1,0 @@
-This is used to test the self-hosted runner if works properly.


### PR DESCRIPTION
## Type of changes ##
CI
## Purpose ##
Switch the GitHub Actions workflow runner from GitHub-hosted (ubuntu-latest) to a self-hosted runner in order to provide more control over the build environment.