### PR TITLE
Throw exit 1 in Makefile test when go test failed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ build:
 
 test:
 	@echo -e ":: $(GREEN)Running tests...$(NC)"
-	@go test -cover ./... && echo -e "==> $(BLUE)All tests passed$(NC)" || echo -e "==> $(RED)Tests failed$(NC)"
+	@go test -cover ./... && echo -e "==> $(BLUE)All tests passed$(NC)" || (echo -e "==> $(RED)Tests failed$(NC)" && exit 1)


### PR DESCRIPTION
# Type of change
- Fix

# Purpose
- Let the Makefile throw exit 1 when the test fails.
- Make the CI test job fails when `make test` fails.