### PR TITLE
Update settings table to set user_id as primary key

### DIFF
--- a/internal/database/full_schema.sql
+++ b/internal/database/full_schema.sql
@@ -14,15 +14,6 @@ CREATE TABLE IF NOT EXISTS users
 );
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
-CREATE TABLE IF NOT EXISTS refresh_tokens
-(
-    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id         UUID REFERENCES users(id) NOT NULL,
-    is_active       BOOLEAN DEFAULT TRUE,
-    expiration_date TIMESTAMPTZ NOT NULL
-);
-CREATE EXTENSION IF NOT EXISTS "pgcrypto";
-
 CREATE TABLE IF NOT EXISTS groups (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     title VARCHAR(255) NOT NULL,
@@ -48,7 +39,7 @@ CREATE TABLE IF NOT EXISTS group_role (
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 CREATE TABLE IF NOT EXISTS settings (
-    user_id UUID REFERENCES users(id) NOT NULL,
+    user_id UUID PRIMARY KEY REFERENCES users(id) NOT NULL,
     username VARCHAR(255),
     linux_username VARCHAR(255)
 );
@@ -58,4 +49,13 @@ CREATE TABLE IF NOT EXISTS public_keys (
     user_id UUID REFERENCES users(id) NOT NULL,
     title VARCHAR(255) NOT NULL,
     public_key TEXT NOT NULL
+);
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE IF NOT EXISTS refresh_tokens
+(
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID REFERENCES users(id) NOT NULL,
+    is_active       BOOLEAN DEFAULT TRUE,
+    expiration_date TIMESTAMPTZ NOT NULL
 );

--- a/internal/database/migrations/202504271041_settings.up.sql
+++ b/internal/database/migrations/202504271041_settings.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS settings (
-    user_id UUID REFERENCES users(id) NOT NULL,
+    user_id UUID PRIMARY KEY REFERENCES users(id) NOT NULL,
     username VARCHAR(255),
     linux_username VARCHAR(255)
 );

--- a/internal/setting/schema.sql
+++ b/internal/setting/schema.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 CREATE TABLE IF NOT EXISTS settings (
-    user_id UUID REFERENCES users(id) NOT NULL,
+    user_id UUID PRIMARY KEY REFERENCES users(id) NOT NULL,
     username VARCHAR(255),
     linux_username VARCHAR(255)
 );


### PR DESCRIPTION
## Type of changes
- Refactor

## Purpose
- Update settings table to set user_id as primary key

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information

```sql
CREATE TABLE IF NOT EXISTS settings (
    user_id UUID REFERENCES users(id) NOT NULL,
    username VARCHAR(255),
    linux_username VARCHAR(255)
);
```

to

```sql
CREATE TABLE IF NOT EXISTS settings (
    user_id UUID PRIMARY KEY REFERENCES users(id) NOT NULL,
    username VARCHAR(255),
    linux_username VARCHAR(255)
);
```

<!-- Optional: Add any other information that would be helpful for the reviewer. Like detail spec, decisions, trade-offs, links, etc. -->