### PR TITLE
Add query parameter 'length' on get public key endpoint

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"errors"
 	"github.com/NYCU-SDC/summer/pkg/problem"
+	"strconv"
 )
 
 var (
@@ -30,6 +31,8 @@ func ErrorHandler(err error) problem.Problem {
 		return problem.NewValidateProblem("invalid callback info")
 	case errors.Is(err, ErrPermissionDenied):
 		return problem.NewForbiddenProblem("permission denied")
+	case errors.Is(err, strconv.ErrSyntax):
+		return problem.NewValidateProblem("invalid syntax")
 	}
 	return problem.Problem{}
 }

--- a/internal/setting/handler.go
+++ b/internal/setting/handler.go
@@ -168,9 +168,10 @@ func (h *Handler) GetUserPublicKeysHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	q := r.URL.Query()
-	short := true // default true: frontend usually only needs short public key
-	if q.Has("short") {
-		short, err = strconv.ParseBool(q.Get("short"))
+	var length int64
+	length = 20 // default 20: frontend usually only needs short public key
+	if q.Has("length") {
+		length, err = strconv.ParseInt(q.Get("length"), 10, 64)
 		if err != nil {
 			h.problemWriter.WriteError(traceCtx, w, err, logger)
 			return
@@ -178,25 +179,14 @@ func (h *Handler) GetUserPublicKeysHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	response := make([]PublicKeyResponse, len(publicKeys))
-	if short {
-		for i, publicKey := range publicKeys {
-			response[i] = PublicKeyResponse{
-				ID:        publicKey.ID.String(),
-				Title:     publicKey.Title,
-				PublicKey: publicKey.PublicKey[:10],
-			}
-		}
-		handlerutil.WriteJSONResponse(w, http.StatusOK, response)
-		return
-	} else {
-		for i, publicKey := range publicKeys {
-			response[i] = PublicKeyResponse{
-				Title:     publicKey.Title,
-				PublicKey: publicKey.PublicKey,
-			}
+
+	for i, publicKey := range publicKeys {
+		response[i] = PublicKeyResponse{
+			ID:        publicKey.ID.String(),
+			Title:     publicKey.Title,
+			PublicKey: publicKey.PublicKey[:min(length, int64(len(publicKey.PublicKey)))],
 		}
 	}
-
 	handlerutil.WriteJSONResponse(w, http.StatusOK, response)
 }
 


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add query parameter 'length' on get public key endpoint.
- Enable frontend to determine how long they want to receive when getting public keys.

## Additional Information
- The default value of length is 20 to prevent overhead when sending long strings through an HTTP response.