### PR TITLE
Fix typo in Unarchive handler logger message

### DIFF
--- a/internal/group/handler.go
+++ b/internal/group/handler.go
@@ -326,9 +326,9 @@ func (h *Handler) ArchiveHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) UnarchiveHandler(w http.ResponseWriter, r *http.Request) {
-	traceCtx, span := h.tracer.Start(r.Context(), "ArchiveHandler")
+	traceCtx, span := h.tracer.Start(r.Context(), "UnarchiveHandler")
 	defer span.End()
-	logger := h.logger.With(zap.String("handler", "ArchiveHandler"))
+	logger := h.logger.With(zap.String("handler", "UnarchiveHandler"))
 
 	groupID := r.PathValue("group_id")
 	groupUUID, err := uuid.Parse(groupID)


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Fix the typo in the unarchive handler logger message to make sure the log is correct. Change `ArchiveHandler` to `UnarchiveHandler`