### PR TITLE
Add onboarding LinuxUsername field

### DIFF
--- a/internal/setting/handler.go
+++ b/internal/setting/handler.go
@@ -19,7 +19,8 @@ import (
 )
 
 type OnboardingRequest struct {
-	Username string `json:"username" validate:"required"`
+	Username      string `json:"username" validate:"required"`
+	LinuxUsername string `json:"linuxUsername" validate:"required,excludesall= \t\r\n"`
 }
 
 type UpdateSettingRequest struct {
@@ -55,7 +56,7 @@ type Store interface {
 	GetPublicKeyByID(ctx context.Context, id uuid.UUID) (PublicKey, error)
 	AddPublicKey(ctx context.Context, publicKey AddPublicKeyParams) (PublicKey, error)
 	DeletePublicKey(ctx context.Context, id uuid.UUID) error
-	OnboardUser(ctx context.Context, userRole string, userID uuid.UUID, username pgtype.Text) error
+	OnboardUser(ctx context.Context, userRole string, userID uuid.UUID, username pgtype.Text, linuxUsername pgtype.Text) error
 }
 
 type Handler struct {
@@ -104,7 +105,7 @@ func (h *Handler) OnboardingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = h.settingStore.OnboardUser(traceCtx, user.Role, user.ID, pgtype.Text{String: request.Username, Valid: true})
+	err = h.settingStore.OnboardUser(traceCtx, user.Role, user.ID, pgtype.Text{String: request.Username, Valid: true}, pgtype.Text{String: request.LinuxUsername, Valid: true})
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
 		return

--- a/internal/setting/service.go
+++ b/internal/setting/service.go
@@ -34,7 +34,7 @@ func NewService(logger *zap.Logger, db DBTX, userStore UserStore) *Service {
 	}
 }
 
-func (s *Service) OnboardUser(ctx context.Context, userRole string, userID uuid.UUID, username pgtype.Text) error {
+func (s *Service) OnboardUser(ctx context.Context, userRole string, userID uuid.UUID, username pgtype.Text, linuxUsername pgtype.Text) error {
 	traceCtx, span := s.tracer.Start(ctx, "OnboardUser")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -48,8 +48,9 @@ func (s *Service) OnboardUser(ctx context.Context, userRole string, userID uuid.
 
 	// update user's setting
 	_, err := s.UpdateSetting(traceCtx, userID, Setting{
-		UserID:   userID,
-		Username: username,
+		UserID:        userID,
+		Username:      username,
+		LinuxUsername: linuxUsername,
 	})
 	if err != nil {
 		span.RecordError(err)


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add a Linux username field in the onboarding endpoint to let users input the basic information for us to create user entries for them.

## Additional information
- Current onboarding endpoint request body is as follow
```json=
{
    username: string,
    linuxUsername: string
}
```