### PR TITLE
[CLUST-49] Rename SQL query function

### DIFF
--- a/internal/group/queries.sql
+++ b/internal/group/queries.sql
@@ -87,56 +87,8 @@ JOIN
 WHERE
     user_id = $1 AND group_id = $2;
 
--- name: ListGroupMembersAscPaged :many
-SELECT *
-FROM memberships
-WHERE group_id = $1
-ORDER BY @SortBy::text ASC
-LIMIT @Size OFFSET @Skip;
-
--- name: ListGroupMembersDescPaged :many
-SELECT *
-FROM memberships
-WHERE group_id = $1
-ORDER BY @SortBy::text DESC
-LIMIT @Size OFFSET @Skip;
-
--- name: AddGroupMember :one
-INSERT INTO memberships (group_id, user_id, role_id)
-VALUES ($1, $2, $3)
-RETURNING *;
-
--- name: RemoveGroupMember :exec
-DELETE FROM memberships
-WHERE group_id = $1 AND user_id = $2;
-
--- name: UpdateMembershipRole :one
-UPDATE memberships
-SET role_id = $1
-WHERE group_id = $2 AND user_id = $3
-RETURNING *;
-
--- name: GetRoleIdByGroupAndUser :one
-SELECT role_id
-FROM memberships
-WHERE group_id = $1 AND user_id = $2;
-
--- name: GetPendingGroupMember :one
-SELECT *
-FROM pending_memberships
-WHERE user_identifier = $1 AND group_id = $2;
-
--- name: DeletePendingGroupMember :exec
-DELETE FROM pending_memberships
-WHERE user_identifier = $1 AND group_id = $2;
-
--- name: CreateRole :one
-INSERT INTO group_role (role, access_level)
-VALUES ($1, $2)
-RETURNING *;
-
 -- name: ListGidNumbers :many
 SELECT gid_number FROM groups WHERE gid_number IS NOT NULL ORDER BY gid_number;
 
--- name: SetGidNumber :exec
+-- name: UpdateGidNumber :exec
 UPDATE groups SET gid_number = $2 WHERE id = $1;

--- a/internal/group/queries.sql
+++ b/internal/group/queries.sql
@@ -40,7 +40,7 @@ WHERE
 ORDER BY
     @SortBy::text DESC LIMIT @Size OFFSET @Skip;
 
--- name: Get :one
+-- name: GetByID :one
 SELECT * FROM groups WHERE id = $1;
 
 -- name: GetIfMember :one

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -353,7 +353,7 @@ func (s *Service) Get(ctx context.Context, groupID uuid.UUID) (Group, error) {
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	group, err := s.queries.Get(ctx, groupID)
+	group, err := s.queries.GetByID(ctx, groupID)
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "groups", "group_id", groupID.String(), logger, "failed to get group by id")
 		span.RecordError(err)

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -397,7 +397,7 @@ func (s *Service) Create(ctx context.Context, userID uuid.UUID, group CreatePara
 		if err != nil {
 			logger.Warn("create LDAP group failed", zap.String("group", groupName), zap.Error(err))
 		} else {
-			err = s.queries.SetGidNumber(ctx, SetGidNumberParams{
+			err = s.queries.UpdateGidNumber(ctx, UpdateGidNumberParams{
 				ID:        newGroup.ID,
 				GidNumber: pgtype.Int4{Int32: int32(gidNumber), Valid: true},
 			})

--- a/internal/grouprole/queries.sql
+++ b/internal/grouprole/queries.sql
@@ -13,11 +13,11 @@ UPDATE group_role SET role = $1, access_level = $2 WHERE id = $3 RETURNING *;
 -- name: Delete :exec
 DELETE FROM group_role WHERE id = $1;
 
--- name: GetGroupRoleByID :one
+-- name: GetByID :one
 SELECT * FROM group_role WHERE id = $1;
 
 -- name: GetUserGroupRole :one
 SELECT gr.* FROM group_role AS gr JOIN memberships AS m ON m.role_id = gr.id WHERE m.user_id = $1 AND m.group_id = $2;
 
--- name: GetGroupRoleByName :one
+-- name: GetByName :one
 SELECT * FROM group_role WHERE role = $1;

--- a/internal/grouprole/service.go
+++ b/internal/grouprole/service.go
@@ -99,7 +99,7 @@ func (s *Service) GetByID(ctx context.Context, roleID uuid.UUID) (GroupRole, err
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	role, err := s.queries.GetGroupRoleByID(ctx, roleID)
+	role, err := s.queries.GetByID(ctx, roleID)
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "group_role", "role_id", roleID.String(), logger, "get group role by id")
 		span.RecordError(err)

--- a/internal/membership/queries.sql
+++ b/internal/membership/queries.sql
@@ -1,4 +1,4 @@
--- name: ListGroupMembersDescPaged :many
+-- name: ListDescPaged :many
 SELECT
     m.group_id,
     m.user_id,
@@ -16,7 +16,7 @@ WHERE group_id = $1
 ORDER BY @SortBy::text DESC
 LIMIT @Size OFFSET @Skip;
 
--- name: ListGroupMembersAscPaged :many
+-- name: ListAscPaged :many
 SELECT
     m.group_id,
     m.user_id,
@@ -49,7 +49,7 @@ SELECT EXISTS (
     WHERE group_id = $1 AND user_id = $2
 ) AS exists;
 
--- name: GetMembershipByUser :one
+-- name: GetByUser :one
 SELECT
     m.user_id,
     m.group_id,
@@ -67,7 +67,7 @@ WHERE
 SELECT COUNT(*) FROM memberships
 WHERE group_id = $1;
 
--- name: AddOrUpdatePending :one
+-- name: CreateOrUpdatePending :one
 INSERT INTO pending_memberships (user_identifier, group_id, role_id)
 VALUES ($1, $2, $3)
 ON CONFLICT (user_identifier, group_id) DO UPDATE SET role_id = EXCLUDED.role_id
@@ -91,7 +91,7 @@ SET role_id = $1
 WHERE group_id = $2 AND user_identifier = $3
 RETURNING *;
 
--- name: AddOrUpdate :one
+-- name: CreateOrUpdate :one
 INSERT INTO memberships (group_id, user_id, role_id)
 VALUES ($1, $2, $3)
 ON CONFLICT (user_id, group_id) DO UPDATE SET role_id = EXCLUDED.role_id
@@ -101,7 +101,7 @@ RETURNING *;
 DELETE FROM memberships
 WHERE group_id = $1 AND user_id = $2;
 
--- name: UpdateMembershipRole :one
+-- name: UpdateRole :one
 UPDATE memberships
 SET role_id = $1
 WHERE group_id = $2 AND user_id = $3

--- a/internal/setting/handler.go
+++ b/internal/setting/handler.go
@@ -55,7 +55,7 @@ type Store interface {
 	UpdateSetting(ctx context.Context, userID uuid.UUID, setting Setting) (Setting, error)
 	GetPublicKeysByUserID(ctx context.Context, userID uuid.UUID) ([]PublicKey, error)
 	GetPublicKeyByID(ctx context.Context, id uuid.UUID) (PublicKey, error)
-	AddPublicKey(ctx context.Context, publicKey AddPublicKeyParams) (PublicKey, error)
+	AddPublicKey(ctx context.Context, publicKey CreatePublicKeyParams) (PublicKey, error)
 	DeletePublicKey(ctx context.Context, id uuid.UUID) error
 	OnboardUser(ctx context.Context, userRole string, userID uuid.UUID, username pgtype.Text, linuxUsername pgtype.Text) error
 	IsLinuxUsernameExists(ctx context.Context, linuxUsername string) (bool, error)
@@ -281,7 +281,7 @@ func (h *Handler) AddUserPublicKeyHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	publicKey := AddPublicKeyParams{
+	publicKey := CreatePublicKeyParams{
 		UserID:    userID,
 		Title:     request.Title,
 		PublicKey: request.PublicKey,

--- a/internal/setting/handler_test.go
+++ b/internal/setting/handler_test.go
@@ -69,7 +69,7 @@ func TestHandler_AddUserPublicKeyHandler(t *testing.T) {
 	}
 
 	store := mocks.NewStore(t)
-	store.On("AddPublicKey", mock.Anything, setting.AddPublicKeyParams{
+	store.On("AddPublicKey", mock.Anything, setting.CreatePublicKeyParams{
 		UserID:    uuid.MustParse("7942c917-4770-43c1-a56a-952186b9970e"),
 		Title:     "Test Title",
 		PublicKey: exampleValidKey,

--- a/internal/setting/queries.sql
+++ b/internal/setting/queries.sql
@@ -1,10 +1,10 @@
 -- name: GetSetting :one
 SELECT * FROM settings WHERE user_id = $1;
 
--- name: SettingExists :one
+-- name: ExistByUserID :one
 SELECT EXISTS (SELECT 1 FROM settings WHERE user_id = $1) AS exists;
 
--- name: LinuxUsernameExists :one
+-- name: ExistByLinuxUsername :one
 SELECT EXISTS (SELECT 1 FROM settings WHERE linux_username = $1) AS exists;
 
 -- name: CreateSetting :one
@@ -19,7 +19,7 @@ SELECT * FROM public_keys WHERE user_id = $1;
 -- name: GetPublicKey :one
 SELECT * FROM public_keys WHERE id = $1;
 
--- name: AddPublicKey :one
+-- name: CreatePublicKey :one
 INSERT INTO public_keys (user_id, title, public_key) VALUES ($1, $2, $3) RETURNING *;
 
 -- name: DeletePublicKey :exec

--- a/internal/setting/service.go
+++ b/internal/setting/service.go
@@ -91,7 +91,7 @@ func (s *Service) FindOrCreateSetting(ctx context.Context, userID uuid.UUID, use
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	exist, err := s.query.SettingExists(ctx, userID)
+	exist, err := s.query.ExistByUserID(ctx, userID)
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "settings", "id", userID.String(), logger, "check setting exists")
 		span.RecordError(err)
@@ -163,12 +163,12 @@ func (s *Service) GetPublicKeyByID(ctx context.Context, id uuid.UUID) (PublicKey
 	return publicKey, nil
 }
 
-func (s *Service) AddPublicKey(ctx context.Context, publicKey AddPublicKeyParams) (PublicKey, error) {
+func (s *Service) AddPublicKey(ctx context.Context, publicKey CreatePublicKeyParams) (PublicKey, error) {
 	traceCtx, span := s.tracer.Start(ctx, "AddPublicKey")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	addedPublicKey, err := s.query.AddPublicKey(ctx, publicKey)
+	addedPublicKey, err := s.query.CreatePublicKey(ctx, publicKey)
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "public_keys", "id", publicKey.UserID.String(), logger, "add public key")
 		span.RecordError(err)
@@ -224,7 +224,7 @@ func (s *Service) IsLinuxUsernameExists(ctx context.Context, linuxUsername strin
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	exists, err := s.query.LinuxUsernameExists(ctx, pgtype.Text{String: linuxUsername, Valid: true})
+	exists, err := s.query.ExistByLinuxUsername(ctx, pgtype.Text{String: linuxUsername, Valid: true})
 	if err != nil {
 		err = databaseutil.WrapDBError(err, logger, "check linux username exists")
 		span.RecordError(err)

--- a/test/testdata/database/membership.go
+++ b/test/testdata/database/membership.go
@@ -24,13 +24,13 @@ func (b MembershipBuilder) Queries() *membership.Queries {
 }
 
 func (b MembershipBuilder) Create(groupID, userID, roleID uuid.UUID) (membership.Membership, error) {
-	params := membership.AddOrUpdateParams{
+	params := membership.CreateOrUpdateParams{
 		GroupID: groupID,
 		UserID:  userID,
 		RoleID:  roleID,
 	}
 
-	result, err := b.Queries().AddOrUpdate(b.t.Context(), params)
+	result, err := b.Queries().CreateOrUpdate(b.t.Context(), params)
 	if err != nil {
 		return membership.Membership{}, err
 	}


### PR DESCRIPTION
## Type of changes
- Refactor

## Purpose
- Rename query function in `settings`, `groups`, `grouprole` and `membership`

## Additional Information
- Use `List` for functions that retrieve all records.
- Use `Get` for functions that retrieve a single record.
- Use `Create` for functions that add new records.
- Use `Update` for functions that modify existing records.
- Use `Delete` for functions that remove records.
- Use `Exist` for functions that check for the existence of a record.
Do not include schema or table names in the function names.
And these should be the function name prefixes.