### PR TITLE
[CLUST-76] default group response sort by created_at

### DIFF
--- a/internal/group/handler.go
+++ b/internal/group/handler.go
@@ -101,6 +101,7 @@ func (h *Handler) GetAllHandler(w http.ResponseWriter, r *http.Request) {
 	pageRequest, err := h.paginationFactory.GetRequest(r)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
 	}
 
 	// verify the role to determine how much data to return

--- a/internal/group/queries.sql
+++ b/internal/group/queries.sql
@@ -5,10 +5,10 @@ SELECT COUNT(*) FROM groups;
 SELECT COUNT(*) FROM memberships WHERE user_id = $1;
 
 -- name: ListAscPaged :many
-SELECT * FROM groups ORDER BY @SortBy::text ASC LIMIT @Size OFFSET @Skip;
+SELECT * FROM groups ORDER BY created_at ASC LIMIT @Size OFFSET @Skip;
 
 -- name: ListDescPaged :many
-SELECT * FROM groups ORDER BY @SortBy::text DESC LIMIT @Size OFFSET @Skip;
+SELECT * FROM groups ORDER BY created_at DESC LIMIT @Size OFFSET @Skip;
 
 -- name: ListIfMemberAscPaged :many
 SELECT

--- a/internal/group/queries.sql
+++ b/internal/group/queries.sql
@@ -23,7 +23,7 @@ JOIN
 WHERE
     m.user_id = $1
 ORDER BY
-    @SortBy::text ASC LIMIT @Size OFFSET @Skip;
+    g.created_at ASC LIMIT @Size OFFSET @Skip;
 
 -- name: ListIfMemberDescPaged :many
 SELECT
@@ -38,7 +38,7 @@ JOIN
 WHERE
     m.user_id = $1
 ORDER BY
-    @SortBy::text DESC LIMIT @Size OFFSET @Skip;
+    g.created_at DESC LIMIT @Size OFFSET @Skip;
 
 -- name: GetByID :one
 SELECT * FROM groups WHERE id = $1;

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -209,27 +209,22 @@ func (s *Service) ListPaged(ctx context.Context, page int, size int, sort string
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	// default sortBy to "created_at" if not provided
-	if sortBy == "" {
-		sortBy = "created_at"
-	}
-
 	var groups []Group
 	var err error
-	if sort == "desc" {
-		params := ListDescPagedParams{
-			Sortby: sortBy,
-			Size:   int32(size),
-			Skip:   int32(page) * int32(size),
-		}
-		groups, err = s.queries.ListDescPaged(ctx, params)
-	} else {
+	if sort == "asc" {
+		logger.Info("list in asc, sortBy", zap.String("sortBy", sortBy))
 		params := ListAscPagedParams{
-			Sortby: sortBy,
-			Size:   int32(size),
-			Skip:   int32(page) * int32(size),
+			Size: int32(size),
+			Skip: int32(page) * int32(size),
 		}
 		groups, err = s.queries.ListAscPaged(ctx, params)
+	} else {
+		logger.Info("list in desc, sortBy", zap.String("sortBy", sortBy))
+		params := ListDescPagedParams{
+			Size: int32(size),
+			Skip: int32(page) * int32(size),
+		}
+		groups, err = s.queries.ListDescPaged(ctx, params)
 	}
 	if err != nil {
 		err = databaseutil.WrapDBError(err, logger, "failed to get groups")
@@ -291,14 +286,14 @@ func (s *Service) listByUserID(ctx context.Context, userID uuid.UUID, page int, 
 		sortBy = "created_at"
 	}
 
-	if sort == "desc" {
-		params := ListIfMemberDescPagedParams{
+	if sort == "asc" {
+		params := ListIfMemberAscPagedParams{
 			UserID: userID,
 			Sortby: sortBy,
 			Size:   int32(size),
 			Skip:   int32(page) * int32(size),
 		}
-		res, err := s.queries.ListIfMemberDescPaged(ctx, params)
+		res, err := s.queries.ListIfMemberAscPaged(ctx, params)
 		if err != nil {
 			err = databaseutil.WrapDBErrorWithKeyValue(err, "groups", "user_id", userID.String(), logger, "failed to get groups by user id")
 			span.RecordError(err)
@@ -324,13 +319,13 @@ func (s *Service) listByUserID(ctx context.Context, userID uuid.UUID, page int, 
 		}
 		return groups, roles, nil
 	} else {
-		params := ListIfMemberAscPagedParams{
+		params := ListIfMemberDescPagedParams{
 			UserID: userID,
 			Sortby: sortBy,
 			Size:   int32(size),
 			Skip:   int32(page) * int32(size),
 		}
-		res, err := s.queries.ListIfMemberAscPaged(ctx, params)
+		res, err := s.queries.ListIfMemberDescPaged(ctx, params)
 		if err != nil {
 			err = databaseutil.WrapDBErrorWithKeyValue(err, "groups", "user_id", userID.String(), logger, "failed to get groups by user id")
 			span.RecordError(err)

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -281,15 +281,9 @@ func (s *Service) listByUserID(ctx context.Context, userID uuid.UUID, page int, 
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	// default sortBy to "created_at" if not provided
-	if sortBy == "" {
-		sortBy = "created_at"
-	}
-
 	if sort == "asc" {
 		params := ListIfMemberAscPagedParams{
 			UserID: userID,
-			Sortby: sortBy,
 			Size:   int32(size),
 			Skip:   int32(page) * int32(size),
 		}
@@ -321,7 +315,6 @@ func (s *Service) listByUserID(ctx context.Context, userID uuid.UUID, page int, 
 	} else {
 		params := ListIfMemberDescPagedParams{
 			UserID: userID,
-			Sortby: sortBy,
 			Size:   int32(size),
 			Skip:   int32(page) * int32(size),
 		}

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -209,6 +209,11 @@ func (s *Service) ListPaged(ctx context.Context, page int, size int, sort string
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
+	// default sortBy to "created_at" if not provided
+	if sortBy == "" {
+		sortBy = "created_at"
+	}
+
 	var groups []Group
 	var err error
 	if sort == "desc" {
@@ -280,6 +285,11 @@ func (s *Service) listByUserID(ctx context.Context, userID uuid.UUID, page int, 
 	traceCtx, span := s.tracer.Start(ctx, "listByUserID")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
+
+	// default sortBy to "created_at" if not provided
+	if sortBy == "" {
+		sortBy = "created_at"
+	}
 
 	if sort == "desc" {
 		params := ListIfMemberDescPagedParams{


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Default the order of group response sort by `created_at` column.
- Default the response of `GET /api/groups` sort in descending order to let the latest group appear on the top/