### PR TITLE
Fix backend stage deploy environment name and separate router, database, and LDAP name

### DIFF
--- a/.deploy/dev/compose.yaml
+++ b/.deploy/dev/compose.yaml
@@ -40,6 +40,7 @@ services:
 
   postgres:
     image: postgres:latest
+    container_name: clustron-db-dev
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s
@@ -54,6 +55,7 @@ services:
 
   ldap:
     image: osixia/openldap:1.5.0
+    container_name: clustron-ldap-dev
     healthcheck:
       test: ["CMD", "cat", "/run/slapd/slapd.pid"]
       interval: 30s

--- a/.deploy/dev/compose.yaml
+++ b/.deploy/dev/compose.yaml
@@ -31,11 +31,11 @@ services:
     labels:
       - "vector.enable=true"
       - "traefik.enable=true"
-      - "traefik.http.routers.clustron-backend.rule=Host(`api.dev.clustron.sdc.nycu.club`)"
-      - "traefik.http.routers.clustron-backend.entrypoints=websecure"
-      - "traefik.http.routers.clustron-backend.tls=true"
-      - "traefik.http.routers.clustron-backend.tls.certresolver=cloudflare"
-      - "traefik.http.services.clustron-backend.loadbalancer.server.port=8080"
+      - "traefik.http.routers.clustron-backend-dev.rule=Host(`api.dev.clustron.sdc.nycu.club`)"
+      - "traefik.http.routers.clustron-backend-dev.entrypoints=websecure"
+      - "traefik.http.routers.clustron-backend-dev.tls=true"
+      - "traefik.http.routers.clustron-backend-dev.tls.certresolver=cloudflare"
+      - "traefik.http.services.clustron-backend-dev.loadbalancer.server.port=8080"
 
 
   postgres:

--- a/.deploy/stage/compose.yaml
+++ b/.deploy/stage/compose.yaml
@@ -30,11 +30,11 @@ services:
     labels:
       - "vector.enable=true"
       - "traefik.enable=true"
-      - "traefik.http.routers.clustron-backend.rule=Host(`api.stage.clustron.sdc.nycu.club`)"
-      - "traefik.http.routers.clustron-backend.entrypoints=websecure"
-      - "traefik.http.routers.clustron-backend.tls=true"
-      - "traefik.http.routers.clustron-backend.tls.certresolver=cloudflare"
-      - "traefik.http.services.clustron-backend.loadbalancer.server.port=8080"
+      - "traefik.http.routers.clustron-backend-stage.rule=Host(`api.stage.clustron.sdc.nycu.club`)"
+      - "traefik.http.routers.clustron-backend-stage.entrypoints=websecure"
+      - "traefik.http.routers.clustron-backend-stage.tls=true"
+      - "traefik.http.routers.clustron-backend-stage.tls.certresolver=cloudflare"
+      - "traefik.http.services.clustron-backend-stage.loadbalancer.server.port=8080"
 
   postgres:
     image: postgres:latest

--- a/.deploy/stage/compose.yaml
+++ b/.deploy/stage/compose.yaml
@@ -38,6 +38,7 @@ services:
 
   postgres:
     image: postgres:latest
+    container_name: clustron-db-stage
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s
@@ -51,6 +52,7 @@ services:
       - clustron_stage
 
   ldap:
+    container_name: clustron-ldap-stage
     image: osixia/openldap:1.5.0
     healthcheck:
       test: ["CMD", "cat", "/run/slapd/slapd.pid"]

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -129,14 +129,14 @@ jobs:
             },
             "method": "deploy",
             "metadata": {
-              "environment": "staging",
+              "environment": "stage",
               "component": "backend"
             },
             "setup": {
               "inject_secret": {
                 "enable": true,
                 "project": "clustron",
-                "environment": "stage",
+                "environment": "staging",
                 "secrets": [
                   {
                     "path": "/google-oauth",

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -129,7 +129,7 @@ jobs:
             },
             "method": "deploy",
             "metadata": {
-              "environment": "stage",
+              "environment": "staging",
               "component": "backend"
             },
             "setup": {


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Separate router name in dev and stage deployment to prevent conflict in Traefik
- Change the environment name for secret injection from "stage" to "staging" to fit the setting in infisical.