### PR TITLE
[CLUST-111] Add link resources in group

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -130,8 +130,8 @@ func main() {
 	jwtService := jwt.NewService(logger, cfg.Secret, 15*time.Minute, 24*time.Hour, userService, dbPool)
 	settingService := setting.NewService(logger, dbPool, userService, ldapClient)
 	groupRoleService := grouprole.NewService(logger, dbPool, settingService)
-	groupService := group.NewService(logger, dbPool, userService, settingService, groupRoleService, ldapClient)
 	memberService := membership.NewService(logger, dbPool, userService, groupRoleService, settingService, ldapClient)
+	groupService := group.NewService(logger, dbPool, userService, memberService, settingService, groupRoleService, ldapClient)
 
 	// Handler
 	authHandler := auth.NewHandler(cfg, logger, validator, problemWriter, userService, jwtService, jwtService, settingService)
@@ -191,6 +191,9 @@ func main() {
 	mux.HandleFunc("GET /api/groups/{group_id}", authMiddleware.HandlerFunc(groupHandler.GetByIDHandler))
 	mux.HandleFunc("POST /api/groups/{group_id}/archive", authMiddleware.HandlerFunc(groupHandler.ArchiveHandler))
 	mux.HandleFunc("POST /api/groups/{group_id}/unarchive", authMiddleware.HandlerFunc(groupHandler.UnarchiveHandler))
+	mux.HandleFunc("POST /api/groups/{group_id}/link", authMiddleware.HandlerFunc(groupHandler.CreateLinkHandler))
+	mux.HandleFunc("PUT /api/groups/{group_id}/link/{link_id}", authMiddleware.HandlerFunc(groupHandler.UpdateLinkHandler))
+	mux.HandleFunc("DELETE /api/groups/{group_id}/link/{link_id}", authMiddleware.HandlerFunc(groupHandler.DeleteLinkHandler))
 
 	// Members
 	mux.HandleFunc("GET /api/groups/{group_id}/members", authMiddleware.HandlerFunc(memberHandler.ListGroupMembersPagedHandler))

--- a/internal/database/migrations/202507181716_link.down.sql
+++ b/internal/database/migrations/202507181716_link.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS links;

--- a/internal/database/migrations/202507181716_link.up.sql
+++ b/internal/database/migrations/202507181716_link.up.sql
@@ -1,0 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE IF NOT EXISTS links (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id UUID REFERENCES groups(id) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    url TEXT NOT NULL
+)

--- a/internal/group/handler.go
+++ b/internal/group/handler.go
@@ -37,6 +37,9 @@ type Store interface {
 	GetTypeByUser(ctx context.Context, userRole string, userID uuid.UUID, groupID uuid.UUID) (grouprole.GroupRole, string, error)
 	GetUserGroupAccessLevel(ctx context.Context, userID uuid.UUID, groupID uuid.UUID) (string, error)
 	GetByID(ctx context.Context, roleID uuid.UUID) (grouprole.GroupRole, error)
+	CreateLink(ctx context.Context, groupID uuid.UUID, title string, Url string) (Link, error)
+	UpdateLink(ctx context.Context, linkID uuid.UUID, title string, Url string) (Link, error)
+	DeleteLink(ctx context.Context, linkID uuid.UUID) error
 }
 
 type LinkResponse struct {
@@ -47,7 +50,7 @@ type LinkResponse struct {
 
 type CreateLinkRequest struct {
 	Title string `json:"title" validate:"required"`
-	Url   string `json:"url" validate:"required,url"`
+	Url   string `json:"url" validate:"required"`
 }
 
 type Response struct {
@@ -267,6 +270,14 @@ func (h *Handler) CreateHandler(w http.ResponseWriter, r *http.Request) {
 		_, err = h.memberStore.Add(traceCtx, group.ID, m.Member, m.Role)
 		if err != nil {
 			// h.problemWriter.WriteError(traceCtx, w, err, logger)
+			continue
+		}
+	}
+
+	// 3. Add links
+	for _, link := range request.Links {
+		_, err = h.store.CreateLink(traceCtx, group.ID, link.Title, link.Url)
+		if err != nil {
 			continue
 		}
 	}

--- a/internal/group/handler.go
+++ b/internal/group/handler.go
@@ -30,7 +30,7 @@ type MemberStore interface {
 //go:generate mockery --name=Store
 type Store interface {
 	ListWithUserScope(ctx context.Context, user jwt.User, page int, size int, sort string, sortBy string) ([]grouprole.UserScope, int /* totalCount */, error)
-	ListByIDWithLinks(ctx context.Context, user jwt.User, groupID uuid.UUID) (WithLinks, error)
+	ListByIDWithLinks(ctx context.Context, user jwt.User, groupID uuid.UUID) (ResponseWithLinks, error)
 	Create(ctx context.Context, userID uuid.UUID, group CreateParams) (Group, error)
 	Archive(ctx context.Context, groupID uuid.UUID) (Group, error)
 	Unarchive(ctx context.Context, groupID uuid.UUID) (Group, error)

--- a/internal/group/policy.csv
+++ b/internal/group/policy.csv
@@ -3,3 +3,6 @@ p, organizer, /api/groups, POST
 p, user, /api/groups/:groupId, GET
 p, organizer, /api/groups/:groupId/archive, POST
 p, organizer, /api/groups/:groupId/unarchive, POST
+p, user, /api/groups/:group_id/link, POST
+p, user, /api/groups/:group_id/link/:linkId, PUT
+p, user, /api/groups/:group_id/link/:linkId, DELETE

--- a/internal/group/queries.sql
+++ b/internal/group/queries.sql
@@ -92,3 +92,24 @@ SELECT gid_number FROM groups WHERE gid_number IS NOT NULL ORDER BY gid_number;
 
 -- name: UpdateGidNumber :exec
 UPDATE groups SET gid_number = $2 WHERE id = $1;
+
+-- name: ListLinksByGroup :many
+SELECT
+    l.id,
+    l.title,
+    l.url
+FROM
+    links AS l
+JOIN
+    groups AS g ON g.id = l.group_id
+WHERE
+    g.id = $1;
+
+-- name: CreateLink :one
+INSERT INTO links (group_id, title, url) VALUES ($1, $2, $3) RETURNING *;
+
+-- name: UpdateLink :one
+UPDATE links SET title = $2, url = $3 WHERE id = $1 RETURNING *;
+
+-- name: DeleteLink :exec
+DELETE FROM links WHERE id = $1;

--- a/internal/group/schema.sql
+++ b/internal/group/schema.sql
@@ -9,3 +9,12 @@ CREATE TABLE IF NOT EXISTS groups (
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE IF NOT EXISTS links (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id UUID REFERENCES groups(id) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    url TEXT NOT NULL
+)

--- a/internal/group/schema.sql
+++ b/internal/group/schema.sql
@@ -17,4 +17,4 @@ CREATE TABLE IF NOT EXISTS links (
     group_id UUID REFERENCES groups(id) NOT NULL,
     title VARCHAR(255) NOT NULL,
     url TEXT NOT NULL
-)
+);

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
 	"strconv"
 
 	databaseutil "github.com/NYCU-SDC/summer/pkg/database"
@@ -608,6 +609,12 @@ func (s *Service) CreateLink(ctx context.Context, groupID uuid.UUID, title strin
 	traceCtx, span := s.tracer.Start(ctx, "CreateLink")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
+
+	// check if the user has access to the group (group owner or group admin)
+	if !s.hasGroupControlAccess(traceCtx, groupId) {
+		logger.Warn("The user's access is not allowed to control this group")
+		return nil, handlerutil.ErrForbidden
+	}
 
 	newLink, err := s.queries.CreateLink(traceCtx, CreateLinkParams{
 		GroupID: groupID,

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -288,7 +288,7 @@ func (s *Service) ListByIDWithUserScope(ctx context.Context, user jwt.User, grou
 	return response, nil
 }
 
-func (s *Service) ListByIDWithLinks(ctx context.Context, user jwt.User, groupID uuid.UUID) (WithLinks, error) {
+func (s *Service) ListByIDWithLinks(ctx context.Context, user jwt.User, groupID uuid.UUID) (ResponseWithLinks, error) {
 	traceCtx, span := s.tracer.Start(ctx, "ListByIDWithUserScope")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -304,7 +304,7 @@ func (s *Service) ListByIDWithLinks(ctx context.Context, user jwt.User, groupID 
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "groups", "group_id", groupID.String(), logger, "Get group by id")
 		span.RecordError(err)
-		return WithLinks{}, err
+		return ResponseWithLinks{}, err
 	}
 
 	// Get link by group ID
@@ -312,7 +312,7 @@ func (s *Service) ListByIDWithLinks(ctx context.Context, user jwt.User, groupID 
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "links", "group_id", groupID.String(), logger, "Get group links")
 		span.RecordError(err)
-		return WithLinks{}, err
+		return ResponseWithLinks{}, err
 	}
 
 	// Get user role in the group
@@ -320,10 +320,10 @@ func (s *Service) ListByIDWithLinks(ctx context.Context, user jwt.User, groupID 
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "groups", "group_id", groupID.String(), logger, "Get group role type")
 		span.RecordError(err)
-		return WithLinks{}, err
+		return ResponseWithLinks{}, err
 	}
 
-	response := WithLinks{
+	response := ResponseWithLinks{
 		// Basic user scope with group information
 		UserScope: grouprole.UserScope{
 			Group: grouprole.Group{

--- a/internal/group/type.go
+++ b/internal/group/type.go
@@ -2,7 +2,7 @@ package group
 
 import "clustron-backend/internal/grouprole"
 
-type WithLinks struct {
+type ResponseWithLinks struct {
 	grouprole.UserScope
 	Links []Link
 }

--- a/internal/group/type.go
+++ b/internal/group/type.go
@@ -1,0 +1,8 @@
+package group
+
+import "clustron-backend/internal/grouprole"
+
+type WithLinks struct {
+	grouprole.UserScope
+	Links []Link
+}

--- a/internal/membership/service.go
+++ b/internal/membership/service.go
@@ -551,7 +551,7 @@ func (s *Service) UpdateRole(ctx context.Context, groupId uuid.UUID, userId uuid
 	logger := logutil.WithContext(traceCtx, s.logger)
 
 	// check if the user has access to the group (group owner or group admin)
-	if !s.hasGroupControlAccess(traceCtx, groupId) {
+	if !s.HasGroupControlAccess(traceCtx, groupId) {
 		logger.Warn("The user's access is not allowed to control this group")
 		return handlerutil.ErrForbidden
 	}

--- a/internal/membership/service.go
+++ b/internal/membership/service.go
@@ -71,7 +71,7 @@ func (s *Service) ListWithPaged(ctx context.Context, groupId uuid.UUID, page int
 	logger := logutil.WithContext(traceCtx, s.logger)
 
 	// check if the user has access to the group (group owner or group admin)
-	if !s.hasGroupControlAccess(traceCtx, groupId) {
+	if !s.HasGroupControlAccess(traceCtx, groupId) {
 		return nil, handlerutil.ErrForbidden
 	}
 
@@ -154,7 +154,7 @@ func (s *Service) Add(ctx context.Context, groupId uuid.UUID, memberIdentifier s
 	}
 
 	// check if the user has access to the group (group owner or group admin)
-	if !s.hasGroupControlAccess(traceCtx, groupId) {
+	if !s.HasGroupControlAccess(traceCtx, groupId) {
 		logger.Warn("The user's access is not allowed to control this group")
 		return nil, handlerutil.ErrForbidden
 	}
@@ -383,7 +383,7 @@ func (s *Service) Remove(ctx context.Context, groupId uuid.UUID, userId uuid.UUI
 	}
 
 	// check if the user has access to the group (group owner or group admin)
-	if !s.hasGroupControlAccess(traceCtx, groupId) {
+	if !s.HasGroupControlAccess(traceCtx, groupId) {
 		logger.Warn("The user's access is not allowed to control this group")
 		return handlerutil.ErrForbidden
 	}
@@ -425,7 +425,7 @@ func (s *Service) Update(ctx context.Context, groupId uuid.UUID, userId uuid.UUI
 	}
 
 	// check if the user has access to the group (group owner or group admin)
-	if !s.hasGroupControlAccess(traceCtx, groupId) {
+	if !s.HasGroupControlAccess(traceCtx, groupId) {
 		logger.Warn("The user's access is not allowed to control this group")
 		return MemberResponse{}, handlerutil.ErrForbidden
 	}
@@ -566,7 +566,7 @@ func (s *Service) canAssignRole(ctx context.Context, groupId uuid.UUID, roleId u
 	return grouprole.AccessLevelRank[accessLevel] > grouprole.AccessLevelRank[targetRole.AccessLevel]
 }
 
-func (s *Service) hasGroupControlAccess(ctx context.Context, groupId uuid.UUID) bool {
+func (s *Service) HasGroupControlAccess(ctx context.Context, groupId uuid.UUID) bool {
 	traceCtx, span := s.tracer.Start(ctx, "HasGroupControlAccess")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -600,7 +600,7 @@ func (s *Service) ListPendingWithPaged(ctx context.Context, groupId uuid.UUID, p
 	logger := logutil.WithContext(traceCtx, s.logger)
 
 	// check if the user has access to the group (group owner or group admin)
-	if !s.hasGroupControlAccess(traceCtx, groupId) {
+	if !s.HasGroupControlAccess(traceCtx, groupId) {
 		logger.Warn("The user's access is not allowed to control this group")
 		return nil, handlerutil.ErrForbidden
 	}
@@ -682,7 +682,7 @@ func (s *Service) UpdatePending(ctx context.Context, groupId uuid.UUID, pendingI
 	}
 
 	// check if the user has access to the group (group owner or group admin)
-	if !s.hasGroupControlAccess(traceCtx, groupId) {
+	if !s.HasGroupControlAccess(traceCtx, groupId) {
 		logger.Warn("The user's access is not allowed to control this group")
 		return PendingMemberResponse{}, handlerutil.ErrForbidden
 	}
@@ -740,7 +740,7 @@ func (s *Service) RemovePending(ctx context.Context, groupId uuid.UUID, pendingI
 	logger := logutil.WithContext(traceCtx, s.logger)
 
 	// check if the user has access to the group (group owner or group admin)
-	if !s.hasGroupControlAccess(traceCtx, groupId) {
+	if !s.HasGroupControlAccess(traceCtx, groupId) {
 		logger.Warn("The user's access is not allowed to control this group")
 		return handlerutil.ErrForbidden
 	}

--- a/internal/membership/service.go
+++ b/internal/membership/service.go
@@ -763,7 +763,7 @@ func (s *Service) RemovePending(ctx context.Context, groupId uuid.UUID, pendingI
 	// Check if the user is a pending member who is allowed to remove themselves after onboarding
 	if jwtUser.Email != pendingMember.UserIdentifier && jwtUser.StudentID.String != pendingMember.UserIdentifier {
 		// check if the user has access to the group (group owner or group admin)
-		if !s.hasGroupControlAccess(traceCtx, groupId) {
+		if !s.HasGroupControlAccess(traceCtx, groupId) {
 			logger.Warn("The user's access is not allowed to control this group")
 			return handlerutil.ErrForbidden
 		}


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Allow the group owner and the group admin to manage link resources in a group.
- Add link CUD endpoints
    - `POST /api/groups/{id}/link`
    - `PUT /api/groups/{id}/link/{linkId}`
    - `DELETE /api/groups/{id}/link/{linkId}`
