### PR TITLE
Remove 'container_name' setting in docker compose to let project name be container name prefix

### DIFF
--- a/.deploy/dev/compose.yaml
+++ b/.deploy/dev/compose.yaml
@@ -42,7 +42,6 @@ services:
 
   postgres:
     image: postgres:latest
-    container_name: clustron-db-dev
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s
@@ -57,7 +56,6 @@ services:
 
   ldap:
     image: osixia/openldap:1.5.0
-    container_name: clustron-ldap-dev
     healthcheck:
       test: ["CMD", "cat", "/run/slapd/slapd.pid"]
       interval: 30s

--- a/.deploy/stage/compose.yaml
+++ b/.deploy/stage/compose.yaml
@@ -40,7 +40,6 @@ services:
 
   postgres:
     image: postgres:latest
-    container_name: clustron-db-stage
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s
@@ -54,7 +53,6 @@ services:
       - internal
 
   ldap:
-    container_name: clustron-ldap-stage
     image: osixia/openldap:1.5.0
     healthcheck:
       test: ["CMD", "cat", "/run/slapd/slapd.pid"]


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Remove 'container_name' setting in docker compose to let project name be container name prefix
- Resolve naming conflict with old containers