### PR TITLE
Default sort by role name when listing group members and pending members

### DIFF
--- a/internal/membership/queries.sql
+++ b/internal/membership/queries.sql
@@ -13,7 +13,7 @@ JOIN group_role AS gr ON gr.id = m.role_id
 JOIN users AS u ON u.id = m.user_id
 JOIN settings AS s ON s.user_id = u.id
 WHERE group_id = $1
-ORDER BY @SortBy::text DESC
+ORDER BY gr.role_name DESC
 LIMIT @Size OFFSET @Skip;
 
 -- name: ListAscPaged :many
@@ -31,7 +31,7 @@ JOIN group_role AS gr ON gr.id = m.role_id
 JOIN users AS u ON u.id = m.user_id
 JOIN settings AS s ON s.user_id = u.id
 WHERE group_id = $1
-ORDER BY @SortBy::text ASC
+ORDER BY gr.role_name ASC
 LIMIT @Size OFFSET @Skip;
 
 -- name: ExistsByIdentifier :one
@@ -124,7 +124,7 @@ SELECT
 FROM pending_memberships AS pm
 JOIN group_role AS gr ON gr.id = pm.role_id
 WHERE pm.group_id = $1
-ORDER BY @SortBy::text DESC
+ORDER BY gr.role_name DESC
 LIMIT @Size OFFSET @Skip;
 
 -- name: ListPendingMembersAscPaged :many
@@ -138,7 +138,7 @@ SELECT
 FROM pending_memberships AS pm
 JOIN group_role AS gr ON gr.id = pm.role_id
 WHERE pm.group_id = $1
-ORDER BY @SortBy::text ASC
+ORDER BY gr.role_name ASC
 LIMIT @Size OFFSET @Skip;
 
 -- name: CountPendingByGroupID :one

--- a/internal/membership/service.go
+++ b/internal/membership/service.go
@@ -80,9 +80,9 @@ func (s *Service) ListWithPaged(ctx context.Context, groupId uuid.UUID, page int
 	if sort == "desc" {
 		params := ListDescPagedParams{
 			GroupID: groupId,
-			Sortby:  sortBy,
-			Size:    int32(size),
-			Skip:    int32(page) * int32(size),
+			//Sortby:  sortBy,	//TODO: Implement various query with corresponding sortBy
+			Size: int32(size),
+			Skip: int32(page) * int32(size),
 		}
 		res, err := s.queries.ListDescPaged(traceCtx, params)
 		if err != nil {
@@ -107,9 +107,9 @@ func (s *Service) ListWithPaged(ctx context.Context, groupId uuid.UUID, page int
 	} else {
 		params := ListAscPagedParams{
 			GroupID: groupId,
-			Sortby:  sortBy,
-			Size:    int32(size),
-			Skip:    int32(page) * int32(size),
+			//Sortby:  sortBy, //TODO: Implement various query with corresponding sortBy
+			Size: int32(size),
+			Skip: int32(page) * int32(size),
 		}
 		res, err := s.queries.ListAscPaged(traceCtx, params)
 		if err != nil {
@@ -686,9 +686,9 @@ func (s *Service) ListPendingWithPaged(ctx context.Context, groupId uuid.UUID, p
 	if sort == "desc" {
 		params := ListPendingMembersDescPagedParams{
 			GroupID: groupId,
-			Sortby:  sortBy,
-			Size:    int32(size),
-			Skip:    int32(page) * int32(size),
+			//Sortby:  sortBy,	//TODO: Implement various query with corresponding sortBy
+			Size: int32(size),
+			Skip: int32(page) * int32(size),
 		}
 		res, err := s.queries.ListPendingMembersDescPaged(traceCtx, params)
 		if err != nil {
@@ -712,9 +712,9 @@ func (s *Service) ListPendingWithPaged(ctx context.Context, groupId uuid.UUID, p
 	} else {
 		params := ListPendingMembersAscPagedParams{
 			GroupID: groupId,
-			Sortby:  sortBy,
-			Size:    int32(size),
-			Skip:    int32(page) * int32(size),
+			//Sortby:  sortBy,	//TODO: Implement various query with corresponding sortBy
+			Size: int32(size),
+			Skip: int32(page) * int32(size),
 		}
 		res, err := s.queries.ListPendingMembersAscPaged(traceCtx, params)
 		if err != nil {


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add a sorting column in the SQL queries that list group members and pending members.
- Default sort by role name.

## Additional
Affected SQL queries in `internal/membership/queries.sql`
- `ListDescPaged`
- `ListAscPaged`
- `ListPendingMembersDescPaged `
- `ListPendingMembersAscPaged`