### PR TITLE
Update grouprole role name existence check

### DIFF
--- a/.deploy/dev/compose.yaml
+++ b/.deploy/dev/compose.yaml
@@ -30,6 +30,7 @@ services:
       - LDAP_BIND_DN=cn=admin,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club
       - LDAP_BIND_PWD=password
       - OTEL_COLLECTOR_URL=10.140.0.3:4317
+      - PRESET_USER=Wwp7InVzZXIiOiJreWxlOTQxMDEwQGdtYWlsLmNvbSIsInJvbGUiOiJhZG1pbiJ9LAp7InVzZXIiOiJiZW5kb3JpczA1MDlAZ21haWwuY29tIiwicm9sZSI6ImFkbWluIn0sCnsidXNlciI6ICJoMjM3azc3Nzc3QGdtYWlsLmNvbSIsICJyb2xlIjoiYWRtaW4ifSwKeyJ1c2VyIjogImFubmllMTA3MzEzMDNAZ21haWwuY29tIiwgInJvbGUiOiJhZG1pbiJ9LAp7InVzZXIiOiAiMXA0MXA0amVqb0BnbWFpbC5jb20iLCAicm9sZSI6ImFkbWluIn0KXQ==
     labels:
       - "vector.enable=true"
       - "traefik.enable=true"

--- a/internal/grouprole/service.go
+++ b/internal/grouprole/service.go
@@ -82,18 +82,6 @@ func (s *Service) Update(ctx context.Context, role UpdateParams) (GroupRole, err
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	exists, err := s.queries.ExistsByRoleName(ctx, role.RoleName)
-	if err != nil {
-		err = databaseutil.WrapDBErrorWithKeyValue(err, "group_role", "role_name", role.RoleName, logger, "check if group role exists")
-		span.RecordError(err)
-		return GroupRole{}, err
-	}
-	if exists {
-		err = fmt.Errorf("role %s already exists, %w", role.RoleName, internal.ErrDatabaseConflict)
-		span.RecordError(err)
-		return GroupRole{}, err
-	}
-
 	updatedRole, err := s.queries.Update(ctx, role)
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "group_role", "role_id", role.ID.String(), logger, "update group role")


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Remove the role name existence check in the update group role service since it should never be there.
- Add the main developer to the preset user and set to admin in the dev environment.