### PR TITLE
[CLUST-134] Implement user search by identifier

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -138,6 +138,7 @@ func main() {
 	settingService.SetMembershipService(memberService)
 
 	// Handler
+	userHandler := user.NewHandler(logger, validator, problemWriter, userService)
 	authHandler := auth.NewHandler(cfg, logger, validator, problemWriter, userService, jwtService, jwtService, authService, settingService)
 	jwtHandler := jwt.NewHandler(logger, validator, problemWriter, jwtService)
 	settingHandler := setting.NewHandler(logger, validator, problemWriter, settingService, userService)
@@ -208,6 +209,9 @@ func main() {
 	mux.HandleFunc("GET /api/groups/{group_id}/pendingMembers", authMiddleware.HandlerFunc(memberHandler.ListPendingMembersPagedHandler))
 	mux.HandleFunc("DELETE /api/groups/{group_id}/pendingMembers/{pending_id}", authMiddleware.HandlerFunc(memberHandler.RemovePendingMemberHandler))
 	mux.HandleFunc("PUT /api/groups/{group_id}/pendingMembers/{pending_id}", authMiddleware.HandlerFunc(memberHandler.UpdatePendingMemberHandler))
+
+	// Search
+	mux.HandleFunc("GET /api/searchUser", authMiddleware.HandlerFunc(userHandler.SearchByIdentifierHandler))
 
 	// handle interrupt signal
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -1,0 +1,75 @@
+package user
+
+import (
+	"context"
+	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
+	"github.com/NYCU-SDC/summer/pkg/pagination"
+	"github.com/NYCU-SDC/summer/pkg/problem"
+	"github.com/go-playground/validator/v10"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type Store interface {
+	SearchByIdentifier(ctx context.Context, query string, page, size int) ([]string, int, error)
+}
+
+type SearchingResponse struct {
+	Identifier string `json:"identifier"`
+}
+
+type Handler struct {
+	logger        *zap.Logger
+	validator     *validator.Validate
+	problemWriter *problem.HttpWriter
+	tracer        trace.Tracer
+
+	store             Store
+	paginationFactory pagination.Factory[SearchingResponse]
+}
+
+func NewHandler(
+	logger *zap.Logger,
+	validator *validator.Validate,
+	problemWriter *problem.HttpWriter,
+	store Store,
+) *Handler {
+	return &Handler{
+		logger:            logger,
+		validator:         validator,
+		problemWriter:     problemWriter,
+		tracer:            otel.Tracer("user/handler"),
+		store:             store,
+		paginationFactory: pagination.NewFactory[SearchingResponse](200, []string{"created_at"}),
+	}
+}
+
+func (h *Handler) SearchByIdentifierHandler(w http.ResponseWriter, r *http.Request) {
+	traceCtx, span := h.tracer.Start(r.Context(), "SearchByIdentifierHandler")
+	defer span.End()
+	logger := h.logger.With(zap.String("handler", "SearchByIdentifierHandler"))
+
+	pageRequest, err := h.paginationFactory.GetRequest(r)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	query := r.URL.Query().Get("query")
+
+	identifiers, totalCount, err := h.store.SearchByIdentifier(traceCtx, query, pageRequest.Page, pageRequest.Size)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	response := make([]SearchingResponse, len(identifiers))
+	for i, identifier := range identifiers {
+		response[i] = SearchingResponse{Identifier: identifier}
+	}
+
+	pageResponse := h.paginationFactory.NewResponse(response, totalCount, pageRequest.Page, pageRequest.Size)
+	handlerutil.WriteJSONResponse(w, http.StatusOK, pageResponse)
+}

--- a/internal/user/policy.csv
+++ b/internal/user/policy.csv
@@ -1,0 +1,1 @@
+p, user, /api/searchUser, GET

--- a/internal/user/queries.sql
+++ b/internal/user/queries.sql
@@ -43,3 +43,19 @@ UPDATE users SET uid_number = $2 WHERE id = $1;
 
 -- name: ListLoginMethods :many
 SELECT providertype, email FROM login_info WHERE user_id = $1;
+
+-- name: CountSearchByIdentifier :one
+SELECT COUNT(*) FROM users WHERE email ILIKE @Query || '%' OR student_id ILIKE @Query || '%';
+
+-- name: SearchByIdentifier :many
+SELECT
+    COALESCE(
+        CASE
+            WHEN email ILIKE @Query || '%' THEN email
+            WHEN student_id ILIKE @Query || '%' THEN student_id
+        END, ''
+    )::text AS identifier
+FROM users
+WHERE email ILIKE @Query || '%' OR student_id ILIKE @Query || '%'
+ORDER BY identifier
+LIMIT @Size OFFSET @Skip;


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add `/api/searchUser` to execute prefix search user by identifier

## Additional Information
- When both a user's `studentID` and `email` are matched in the search, `email` will be returned with higher priority.