### PR TITLE
[CLUST-163] Remove unused userStore interface in jwt package

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -135,7 +135,7 @@ func main() {
 
 	// Service
 	userService := user.NewService(logger, cfg.PresetUser, dbPool)
-	jwtService := jwt.NewService(logger, cfg.Secret, cfg.OAuthProxySecret, 15*time.Minute, 24*time.Hour, userService, dbPool)
+	jwtService := jwt.NewService(logger, cfg.Secret, cfg.OAuthProxySecret, 15*time.Minute, 24*time.Hour, dbPool)
 	authService := auth.NewService(logger, dbPool, userService, 15*time.Minute, cfg.PresetUser)
 	settingService := setting.NewService(logger, dbPool, userService, ldapClient)
 	groupRoleService := grouprole.NewService(logger, dbPool, settingService)

--- a/internal/jwt/service.go
+++ b/internal/jwt/service.go
@@ -2,7 +2,6 @@ package jwt
 
 import (
 	"clustron-backend/internal"
-	"clustron-backend/internal/user"
 	"context"
 	"errors"
 	"fmt"
@@ -21,29 +20,23 @@ import (
 
 const Issuer = "clustron"
 
-type Store interface {
-	GetByID(ctx context.Context, id uuid.UUID) (user.User, error)
-}
-
 type Service struct {
 	logger                 *zap.Logger
 	secret                 string
 	oauthProxySecret       string
 	expiration             time.Duration
 	refreshTokenExpiration time.Duration
-	userStore              Store
 	tracer                 trace.Tracer
 	queries                *Queries
 }
 
-func NewService(logger *zap.Logger, secret string, oauthProxySecret string, expiration, refreshTokenExpiration time.Duration, userStore Store, db DBTX) *Service {
+func NewService(logger *zap.Logger, secret string, oauthProxySecret string, expiration, refreshTokenExpiration time.Duration, db DBTX) *Service {
 	return &Service{
 		logger:                 logger,
 		secret:                 secret,
 		oauthProxySecret:       oauthProxySecret,
 		expiration:             expiration,
 		refreshTokenExpiration: refreshTokenExpiration,
-		userStore:              userStore,
 		tracer:                 otel.Tracer("jwt/service"),
 		queries:                New(db),
 	}


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Remove `userStore` interface in `jwt` package since it is unused to reduce redundant components.