### PR TITLE
Wrap PR type and PR purpose in double quotes in n8n deploy request to prevent parsing errors.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -140,8 +140,8 @@ jobs:
               "commit": "${{ github.sha }}",
               "pr_number": "${{ github.event.number }}",
               "pr_title": "${{ github.event.pull_request.title }}",
-              "pr_type": ${{ env.PR_TYPE }},
-              "pr_purpose": ${{ env.PR_PURPOSE }}
+              "pr_type": "${{ env.PR_TYPE }}",
+              "pr_purpose": "${{ env.PR_PURPOSE }}"
             },
             "method": "deploy",
             "metadata": {

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -122,8 +122,8 @@ jobs:
 
       - name: Process PR body for webhook
         run: |
-          PR_TYPE=$(echo '${{ steps.extract.outputs.type_block }}' | jq -R -s @json)
-          PR_PURPOSE=$(echo '${{ steps.extract.outputs.purpose_block }}' | jq -R -s @json)
+          PR_TYPE=$(echo "${{ steps.extract.outputs.type_block }}" | jq -R -s @json)
+          PR_PURPOSE=$(echo "${{ steps.extract.outputs.purpose_block }}" | jq -R -s @json)
           echo "PR_TYPE=$PR_TYPE" >> $GITHUB_ENV
           echo "PR_PURPOSE=$PR_PURPOSE" >> $GITHUB_ENV
 
@@ -140,8 +140,8 @@ jobs:
               "commit": "${{ github.sha }}",
               "pr_number": "${{ github.event.number }}",
               "pr_title": "${{ github.event.pull_request.title }}",
-              "pr_type": "${{ env.PR_TYPE }}",
-              "pr_purpose": "${{ env.PR_PURPOSE }}"
+              "pr_type": ${{ env.PR_TYPE }},
+              "pr_purpose": ${{ env.PR_PURPOSE }}
             },
             "method": "deploy",
             "metadata": {


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Wrap PR type and PR purpose in double quotes in the n8n deploy request to prevent parsing errors when having `'` in pr description.