### PR TITLE
[CLUST-297] Implement LDAP user binding endpoint

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -149,7 +149,7 @@ func main() {
 
 	// Service
 	redisService := redis.NewService(logger, cfg.RedisURL)
-	userService := user.NewService(logger, cfg.PresetUser, dbPool)
+	userService := user.NewService(logger, cfg.PresetUser, dbPool, ldapClient)
 	jwtService := jwt.NewService(logger, cfg.Secret, cfg.OAuthProxySecret, 15*time.Minute, 24*time.Hour, dbPool)
 	authService := auth.NewService(logger, dbPool, userService, 15*time.Minute, cfg.PresetUser)
 	settingService := setting.NewService(logger, settingQuerier, userService, ldapClient)
@@ -215,6 +215,7 @@ func main() {
 	mux.HandleFunc("GET /api/settings", authMiddleware.HandlerFunc(settingHandler.GetUserSettingHandler))
 	mux.HandleFunc("PUT /api/settings", authMiddleware.HandlerFunc(userHandler.UpdateFullNameHandler))
 	mux.HandleFunc("PUT /api/password", authMiddleware.HandlerFunc(settingHandler.UpdatePasswordHandler))
+	mux.HandleFunc("PUT /api/users/{user_id}/ldapBind", authMiddleware.HandlerFunc(settingHandler.BindLDAPUserHandler))
 
 	// Public Key
 	mux.HandleFunc("GET /api/publickey", authMiddleware.HandlerFunc(settingHandler.GetUserPublicKeysHandler))

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -27,9 +27,10 @@ var (
 	ErrDatabaseConflict = errors.New("database conflict")
 
 	// Setting Errors
-	ErrInvalidPublicKey   = errors.New("invalid public key")
-	ErrInvalidFingerprint = errors.New("invalid fingerprint")
-	ErrInvalidPassword    = errors.New("invalid password")
+	ErrInvalidPublicKey     = errors.New("invalid public key")
+	ErrInvalidFingerprint   = errors.New("invalid fingerprint")
+	ErrInvalidPassword      = errors.New("invalid password")
+	ErrLDAPUserAlreadyBound = errors.New("LDAP user already bound to another account")
 
 	// User Errors
 	ErrInvalidFullName = errors.New("invalid full name")
@@ -71,6 +72,7 @@ func NewProblemWriter() *problem.HttpWriter {
 
 func ErrorHandler(err error) problem.Problem {
 	switch {
+	// Auth Errors
 	case errors.Is(err, ErrInvalidRefreshToken):
 		return problem.NewNotFoundProblem("refresh token not found")
 	case errors.Is(err, ErrProviderNotFound):
@@ -85,10 +87,16 @@ func ErrorHandler(err error) problem.Problem {
 		return problem.NewForbiddenProblem("permission denied")
 	case errors.Is(err, ErrNotModuleOwner):
 		return problem.NewForbiddenProblem("user does not own this module")
-	case errors.Is(err, ErrDatabaseConflict):
-		return NewConflictProblem("database conflict")
+	case errors.Is(err, ErrBindingAccountConflict):
+		return problem.NewBadRequestProblem("binding account conflict")
 	case errors.Is(err, ErrAlreadyOnboarded):
 		return problem.NewBadRequestProblem("user already onboarded")
+	case errors.Is(err, ErrNewStateFailed):
+		return problem.NewInternalServerProblem("failed to generate new state")
+	// Database Errors
+	case errors.Is(err, ErrDatabaseConflict):
+		return NewConflictProblem("database conflict")
+	// Validation Errors
 	case errors.Is(err, strconv.ErrSyntax):
 		return problem.NewValidateProblem("invalid syntax")
 	case errors.As(err, new(*json.SyntaxError)):
@@ -97,20 +105,23 @@ func ErrorHandler(err error) problem.Problem {
 		return problem.NewValidateProblem("invalid username: " + err.Error())
 	case errors.As(err, &ErrInvalidSetting{}):
 		return problem.NewValidateProblem("invalid setting: " + err.Error())
+	// Setting Errors
 	case errors.Is(err, ErrInvalidPublicKey):
 		return problem.NewValidateProblem("invalid public key")
 	case errors.Is(err, ErrInvalidFingerprint):
 		return problem.NewBadRequestProblem("invalid fingerprint")
-	case errors.Is(err, ErrBindingAccountConflict):
-		return problem.NewBadRequestProblem("binding account conflict")
+	case errors.Is(err, ErrInvalidPassword):
+		return problem.NewValidateProblem("invalid password")
+	case errors.Is(err, ErrLDAPUserAlreadyBound):
+		return problem.NewBadRequestProblem("LDAP user already bound to another account")
+	// User Errors
 	case errors.Is(err, ErrInvalidFullName):
 		return problem.NewValidateProblem("invalid full name")
 	case errors.Is(err, ErrInvalidRoleType):
 		return problem.NewValidateProblem("invalid role type")
 	case errors.Is(err, ErrSelfDeletion):
 		return problem.NewBadRequestProblem("cannot delete yourself")
-	case errors.Is(err, ErrInvalidPassword):
-		return problem.NewValidateProblem("invalid password")
+	// Group Errors
 	case errors.Is(err, ErrGroupNotFound):
 		return problem.NewNotFoundProblem(err.Error())
 	// LDAP Client Errors

--- a/internal/jwt/middleware.go
+++ b/internal/jwt/middleware.go
@@ -3,12 +3,13 @@ package jwt
 import (
 	"clustron-backend/internal"
 	"context"
+	"net/http"
+
 	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
 	logutil "github.com/NYCU-SDC/summer/pkg/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"net/http"
 )
 
 type Verifier interface {

--- a/internal/ldap/user.go
+++ b/internal/ldap/user.go
@@ -100,7 +100,7 @@ func (c *Client) GetUserInfo(uid string) (*ldap.Entry, error) {
 	base := "ou=People," + c.Config.LDAPBaseDN
 	filter := fmt.Sprintf("(uid=%s)", ldap.EscapeFilter(uid))
 	attributes := []string{
-		"dn", "uid", "cn", "sn", "sshPublicKey", "homeDirectory", "loginShell",
+		"dn", "uid", "cn", "sn", "sshPublicKey", "homeDirectory", "loginShell", "uidNumber",
 	}
 
 	result, err := c.SearchByFilter(base, filter, attributes)

--- a/internal/setting/handler.go
+++ b/internal/setting/handler.go
@@ -1,13 +1,11 @@
 package setting
 
 import (
-	"bufio"
 	"clustron-backend/internal"
 	"clustron-backend/internal/jwt"
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,7 +24,7 @@ import (
 
 type OnboardingRequest struct {
 	FullName      string `json:"fullName" validate:"required"`
-	LinuxUsername string `json:"linuxUsername" validate:"required,excludesall= \t\r\n"`
+	LinuxUsername string `json:"linuxUsername" validate:"required,max=32,linux_username_format,linux_username_blacklist"`
 	Password      string `json:"password" validate:"required,min=8"`
 }
 
@@ -60,6 +58,19 @@ type UpdatePasswordRequest struct {
 	NewPassword string `json:"newPassword" validate:"required,min=8"`
 }
 
+type BindLDAPUserRequest struct {
+	LinuxUsername string `json:"linuxUsername" validate:"required,max=32,linux_username_format,linux_username_blacklist"`
+}
+
+type BindLDAPUserResponse struct {
+	ID            string `json:"id"`
+	FullName      string `json:"fullName"`
+	Email         string `json:"email"`
+	StudentID     string `json:"studentId"`
+	LinuxUsername string `json:"linuxUsername"`
+	Role          string `json:"role"`
+}
+
 //go:generate mockery --name Store
 type Store interface {
 	GetLDAPUserInfoByUserID(ctx context.Context, userID uuid.UUID) (LDAPUserInfo, error)
@@ -70,6 +81,7 @@ type Store interface {
 	OnboardUser(ctx context.Context, userID uuid.UUID, fullName pgtype.Text, linuxUsername pgtype.Text) error
 	IsLinuxUsernameExists(ctx context.Context, linuxUsername string) (bool, error)
 	UpdatePassword(ctx context.Context, userID uuid.UUID, newPassword string) error
+	BindLDAPUser(ctx context.Context, userID uuid.UUID, linuxUsername string) (LDAPUserInfo, error)
 }
 
 type Handler struct {
@@ -82,62 +94,6 @@ type Handler struct {
 	userStore    UserStore
 }
 
-var Blacklist = LinuxUsernameBlacklist{
-	// Core System Users
-	"root":          {},
-	"daemon":        {},
-	"bin":           {},
-	"sys":           {},
-	"sync":          {},
-	"games":         {},
-	"man":           {},
-	"lp":            {},
-	"mail":          {},
-	"news":          {},
-	"uucp":          {},
-	"proxy":         {},
-	"admin":         {},
-	"administrator": {},
-
-	// Service-Specific Accounts
-	"syslog":     {},
-	"www-data":   {},
-	"backup":     {},
-	"list":       {},
-	"irc":        {},
-	"gnats":      {},
-	"nobody":     {},
-	"nogroup":    {},
-	"messagebus": {},
-	"sshd":       {},
-
-	// Modern Systemd / Virtual Users
-	"systemd-network":  {},
-	"systemd-resolve":  {},
-	"systemd-timesync": {},
-	"systemd-coredump": {},
-	"_apt":             {},
-	"uuidd":            {},
-	"tcpdump":          {},
-
-	// Database and Common App Defaults
-	"mysql":    {},
-	"postgres": {},
-	"apache":   {},
-	"nginx":    {},
-	"postfix":  {},
-
-	// suggested system name
-	"dhcpcd":        {},
-	"pollinate":     {},
-	"polkitd":       {},
-	"tss":           {},
-	"landscape":     {},
-	"fwupd-refresh": {},
-	"usbmux":        {},
-	"sssd":          {},
-}
-
 func validatePublicKey(key string) error {
 	_, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
 	if err != nil {
@@ -147,10 +103,6 @@ func validatePublicKey(key string) error {
 }
 
 func NewHandler(logger *zap.Logger, v *validator.Validate, problemWriter *problem.HttpWriter, store Store, userStore UserStore) Handler {
-	err := loadSystemUsers()
-	if err != nil {
-		logger.Error("fail to read user from system")
-	}
 	return Handler{
 		logger:        logger,
 		validator:     v,
@@ -176,6 +128,27 @@ func (h *Handler) OnboardingHandler(w http.ResponseWriter, r *http.Request) {
 	var request OnboardingRequest
 	err = handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &request)
 	if err != nil {
+		if validationErrors, ok := err.(validator.ValidationErrors); ok {
+			firstErr := validationErrors[0]
+			var reason string
+			switch firstErr.Tag() {
+			case "required":
+				reason = "Linux username cannot be empty"
+			case "min":
+				reason = fmt.Sprintf("%s must be at least %s characters long", firstErr.Field(), firstErr.Param())
+			case "max":
+				reason = fmt.Sprintf("%s cannot be longer than %s characters", firstErr.Field(), firstErr.Param())
+			case "linux_username_format":
+				reason = fmt.Sprintf("%s must start with a lowercase letter or underscore, followed by lowercase letters, numbers, underscores, or hyphens, and can end with a dollar sign", firstErr.Field())
+			case "linux_username_blacklist":
+				reason = fmt.Sprintf("%s contain reserved keywords", firstErr.Field())
+			default:
+				reason = fmt.Sprintf("%s is invalid", firstErr.Field())
+			}
+			err = internal.ErrInvalidSetting{Reason: reason}
+			h.problemWriter.WriteError(traceCtx, w, err, logger)
+			return
+		}
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
 		return
 	}
@@ -192,10 +165,14 @@ func (h *Handler) OnboardingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// check if the linux username is valid first
-	err = h.IsLinuxUsernameValid(traceCtx, request.LinuxUsername)
+	// check if the linux username exists
+	exists, err := h.isLinuxUsernameExists(traceCtx, request.LinuxUsername)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+	if exists {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidLinuxUsername{Reason: "Linux username is already exists"}, logger)
 		return
 	}
 
@@ -380,60 +357,6 @@ func (h *Handler) DeletePublicKeyHandler(w http.ResponseWriter, r *http.Request)
 	handlerutil.WriteJSONResponse(w, http.StatusOK, nil)
 }
 
-func (h *Handler) IsLinuxUsernameValid(ctx context.Context, linuxUsername string) error {
-	if len(linuxUsername) == 0 {
-		return internal.ErrInvalidLinuxUsername{
-			Reason: "Linux username cannot be empty",
-		}
-	}
-
-	if len(linuxUsername) > 32 {
-		return internal.ErrInvalidLinuxUsername{
-			Reason: "Linux username cannot be longer than 32 characters",
-		}
-	}
-
-	if linuxUsername[0] == '-' {
-		return internal.ErrInvalidLinuxUsername{
-			Reason: "Linux username cannot start with a hyphen",
-		}
-	}
-
-	if strings.ContainsAny(linuxUsername, " :/") {
-		return internal.ErrInvalidLinuxUsername{
-			Reason: "Linux username cannot contain colon or slash",
-		}
-	}
-
-	// check if the linux username matches the pattern. source: https://www.unix.com/man_page/linux/8/useradd/
-	pattern := `^[a-z_][a-z0-9_-]*[$]?$`
-	regex := regexp.MustCompile(pattern)
-	if !regex.MatchString(linuxUsername) {
-		return internal.ErrInvalidLinuxUsername{
-			Reason: "Linux username must start with a lowercase letter or underscore, followed by lowercase letters, numbers, underscores, or hyphens, and can end with a dollar sign",
-		}
-	}
-
-	if _, exists := Blacklist[linuxUsername]; exists {
-		return internal.ErrInvalidLinuxUsername{
-			Reason: "Linux username contain reserved keywords",
-		}
-	}
-
-	isLinuxUsernameExists, err := h.settingStore.IsLinuxUsernameExists(ctx, linuxUsername)
-	if err != nil {
-		h.logger.Error("Failed to check if linux username exists", zap.Error(err))
-		return err
-	}
-
-	if isLinuxUsernameExists {
-		return internal.ErrInvalidLinuxUsername{
-			Reason: "Linux username already exists",
-		}
-	}
-	return nil
-}
-
 func (h *Handler) UpdatePasswordHandler(w http.ResponseWriter, r *http.Request) {
 	traceCtx, span := h.tracer.Start(r.Context(), "UpdatePasswordHandler")
 	defer span.End()
@@ -467,42 +390,94 @@ func (h *Handler) UpdatePasswordHandler(w http.ResponseWriter, r *http.Request) 
 	handlerutil.WriteJSONResponse(w, http.StatusOK, nil)
 }
 
+func (h *Handler) BindLDAPUserHandler(w http.ResponseWriter, r *http.Request) {
+	traceCtx, span := h.tracer.Start(r.Context(), "BindUserLDAPHandler")
+	defer span.End()
+	logger := h.logger.With(zap.String("handler", "BindUserLDAPHandler"))
+
+	idStr := r.PathValue("user_id")
+	userID, err := handlerutil.ParseUUID(idStr)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	var req BindLDAPUserRequest
+	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
+		if validationErrors, ok := err.(validator.ValidationErrors); ok {
+			firstErr := validationErrors[0]
+			var reason string
+			switch firstErr.Tag() {
+			case "required":
+				reason = "Linux username cannot be empty"
+			case "min":
+				reason = fmt.Sprintf("%s must be at least %s characters long", firstErr.Field(), firstErr.Param())
+			case "max":
+				reason = fmt.Sprintf("%s cannot be longer than %s characters", firstErr.Field(), firstErr.Param())
+			case "linux_username_format":
+				reason = fmt.Sprintf("%s must start with a lowercase letter or underscore, followed by lowercase letters, numbers, underscores, or hyphens, and can end with a dollar sign", firstErr.Field())
+			case "linux_username_blacklist":
+				reason = fmt.Sprintf("%s contain reserved keywords", firstErr.Field())
+			default:
+				reason = fmt.Sprintf("%s is invalid", firstErr.Field())
+			}
+			err = internal.ErrInvalidSetting{Reason: reason}
+			h.problemWriter.WriteError(traceCtx, w, err, logger)
+			return
+		}
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	if strings.TrimSpace(req.LinuxUsername) == "" {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidSetting{Reason: "Linux Username cannot be empty"}, logger)
+		return
+	}
+
+	exists, err := h.isLinuxUsernameExists(traceCtx, req.LinuxUsername)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+	if !exists {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidLinuxUsername{Reason: "Linux username doesn't exists in LDAP"}, logger)
+		return
+	}
+
+	ldapUserInfo, err := h.settingStore.BindLDAPUser(traceCtx, userID, req.LinuxUsername)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	updatedUser, err := h.userStore.GetByID(traceCtx, userID)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	handlerutil.WriteJSONResponse(w, http.StatusOK, BindLDAPUserResponse{
+		ID:            updatedUser.ID.String(),
+		FullName:      updatedUser.FullName.String,
+		Email:         updatedUser.Email,
+		StudentID:     updatedUser.StudentID.String,
+		LinuxUsername: ldapUserInfo.Username,
+		Role:          strings.ToUpper(updatedUser.Role),
+	})
+}
+
+func (h *Handler) isLinuxUsernameExists(ctx context.Context, linuxUsername string) (bool, error) {
+	isLinuxUsernameExists, err := h.settingStore.IsLinuxUsernameExists(ctx, linuxUsername)
+	if err != nil {
+		h.logger.Error("Failed to check if linux username exists", zap.Error(err))
+		return false, err
+	}
+
+	return isLinuxUsernameExists, nil
+}
+
 func isValidPassword(pass string) bool {
 	hasLetter := regexp.MustCompile(`[a-zA-Z]`).MatchString(pass)
 	hasNumber := regexp.MustCompile(`[0-9]`).MatchString(pass)
 	return hasLetter && hasNumber
-}
-
-func loadSystemUsers() error {
-	file, err := os.Open("/etc/passwd")
-	if err != nil {
-		return err
-	}
-	defer func(file *os.File) {
-		closeErr := file.Close()
-		if err != nil {
-			err = closeErr
-		}
-	}(file)
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Skip empty lines or comments
-		if len(line) == 0 || line[0] == '#' {
-			continue
-		}
-
-		// /etc/passwd format: name:password:UID:GID:comment:home:shell
-		parts := strings.Split(line, ":")
-		if len(parts) > 0 {
-			username := strings.ToLower(strings.TrimSpace(parts[0]))
-			if username != "" {
-				Blacklist[username] = struct{}{}
-			}
-		}
-	}
-
-	return scanner.Err()
 }

--- a/internal/setting/handler_test.go
+++ b/internal/setting/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"clustron-backend/internal/user/role"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -537,7 +538,7 @@ func TestHandler_OnboardingHandler(t *testing.T) {
 
 			userStore := mocks.NewUserStore(t)
 
-			h := setting.NewHandler(logger, validator.New(), problem.NewWithMapping(internal.ErrorHandler), store, userStore)
+			h := setting.NewHandler(logger, internal.NewValidator(), problem.NewWithMapping(internal.ErrorHandler), store, userStore)
 
 			requestBody, err := json.Marshal(tc.body)
 			if err != nil {
@@ -809,6 +810,155 @@ func TestHandler_UpdatePasswordHandler(t *testing.T) {
 			} else {
 				assert.Panics(t, func() {
 					h.UpdatePasswordHandler(w, r)
+				}, tc.name)
+			}
+		})
+	}
+}
+
+func TestHandler_BindLDAPUserHandler(t *testing.T) {
+	testCases := []struct {
+		name           string
+		body           setting.BindLDAPUserRequest
+		jwtUser        *jwt.User
+		setupMock      func(store *mocks.Store, userStore *mocks.UserStore, user *jwt.User)
+		customBody     []byte
+		customUserID   string
+		expectedStatus int
+	}{
+		{
+			name: "Should bind LDAP user successfully",
+			body: setting.BindLDAPUserRequest{
+				LinuxUsername: "testuser",
+			},
+			jwtUser: &jwt.User{
+				ID:   uuid.New(),
+				Role: role.User.String(),
+			},
+			setupMock: func(store *mocks.Store, userStore *mocks.UserStore, jwtUser *jwt.User) {
+				store.On("BindLDAPUser", mock.Anything, jwtUser.ID, "testuser").Return(setting.LDAPUserInfo{}, nil)
+				store.On("IsLinuxUsernameExists", mock.Anything, "testuser").Return(true, nil).Once()
+				userStore.On("GetByID", mock.Anything, jwtUser.ID).Return(user.User{
+					ID:       jwtUser.ID,
+					Role:     role.User.String(),
+					FullName: pgtype.Text{String: "Test User", Valid: true},
+				}, nil)
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Should return error when Linux username is empty",
+			body: setting.BindLDAPUserRequest{
+				LinuxUsername: "",
+			},
+			jwtUser:        &jwt.User{ID: uuid.New(), Role: role.User.String()},
+			setupMock:      func(store *mocks.Store, userStore *mocks.UserStore, user *jwt.User) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Should return error when Linux username is too long",
+			body: setting.BindLDAPUserRequest{
+				LinuxUsername: "12345678901234567890123456789012345678901234567890",
+			},
+			jwtUser:        &jwt.User{ID: uuid.New(), Role: role.User.String()},
+			setupMock:      func(store *mocks.Store, userStore *mocks.UserStore, user *jwt.User) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Should return error when Linux username contains invalid characters",
+			body: setting.BindLDAPUserRequest{
+				LinuxUsername: "invalid user",
+			},
+			jwtUser:        &jwt.User{ID: uuid.New(), Role: role.User.String()},
+			setupMock:      func(store *mocks.Store, userStore *mocks.UserStore, user *jwt.User) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Should return error when Linux username contains invalid characters",
+			body: setting.BindLDAPUserRequest{
+				LinuxUsername: "invalid:user",
+			},
+			jwtUser:        &jwt.User{ID: uuid.New(), Role: role.User.String()},
+			setupMock:      func(store *mocks.Store, userStore *mocks.UserStore, user *jwt.User) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Should return error when Linux username in blacklist",
+			body: setting.BindLDAPUserRequest{
+				LinuxUsername: "root",
+			},
+			jwtUser:        &jwt.User{ID: uuid.New(), Role: role.User.String()},
+			setupMock:      func(store *mocks.Store, userStore *mocks.UserStore, user *jwt.User) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Should return error when user id is invalid",
+			body: setting.BindLDAPUserRequest{
+				LinuxUsername: "testuser",
+			},
+			jwtUser:        &jwt.User{ID: uuid.Nil, Role: role.User.String()},
+			customUserID:   "invalid-uuid",
+			setupMock:      func(store *mocks.Store, userStore *mocks.UserStore, user *jwt.User) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Should return error when DB fails",
+			body: setting.BindLDAPUserRequest{
+				LinuxUsername: "testuser",
+			},
+			jwtUser: &jwt.User{
+				ID:   uuid.New(),
+				Role: role.User.String(),
+			},
+			setupMock: func(store *mocks.Store, userStore *mocks.UserStore, jwtUser *jwt.User) {
+				store.On("BindLDAPUser", mock.Anything, jwtUser.ID, "testuser").Return(setting.LDAPUserInfo{}, assert.AnError)
+				store.On("IsLinuxUsernameExists", mock.Anything, "testuser").Return(true, nil).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, err := zap.NewDevelopment()
+			if err != nil {
+				t.Fatalf("failed to create logger: %v", err)
+			}
+			store := mocks.NewStore(t)
+			userStore := mocks.NewUserStore(t)
+
+			if tc.setupMock != nil {
+				tc.setupMock(store, userStore, tc.jwtUser)
+			}
+
+			h := setting.NewHandler(logger, internal.NewValidator(), internal.NewProblemWriter(), store, userStore)
+
+			var requestBody []byte
+			if tc.customBody != nil {
+				requestBody = tc.customBody
+			} else {
+				requestBody, err = json.Marshal(tc.body)
+				if err != nil {
+					t.Fatalf("failed to marshal request body: %v", err)
+				}
+			}
+
+			r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/users/%s/ldapBind", tc.jwtUser.ID.String()), bytes.NewReader(requestBody))
+			w := httptest.NewRecorder()
+
+			if tc.customUserID != "" {
+				r.SetPathValue("user_id", tc.customUserID)
+			} else {
+				r.SetPathValue("user_id", tc.jwtUser.ID.String())
+			}
+
+			if tc.jwtUser != nil {
+				r = r.WithContext(context.WithValue(r.Context(), internal.UserContextKey, *tc.jwtUser))
+				h.BindLDAPUserHandler(w, r)
+				assert.Equal(t, tc.expectedStatus, w.Code, tc.name)
+			} else {
+				assert.Panics(t, func() {
+					h.BindLDAPUserHandler(w, r)
 				}, tc.name)
 			}
 		})

--- a/internal/setting/policy.csv
+++ b/internal/setting/policy.csv
@@ -6,3 +6,4 @@ p, user, /api/publickey/:fingerprint, DELETE
 p, role_not_setup, /api/onboarding, POST
 p, user, /api/password, PUT
 p, user, /api/publickey, DELETE
+p, admin, /api/users/:user_id/ldapBind, PUT

--- a/internal/setting/queries.sql
+++ b/internal/setting/queries.sql
@@ -37,5 +37,11 @@ SELECT ldap_user.uid_number, u.* FROM ldap_user JOIN users u ON u.id = ldap_user
 -- name: CreateLDAPUser :exec
 INSERT INTO ldap_user (id, uid_number) VALUES ($1, $2);
 
+-- name: UpdateLDAPUser :exec
+UPDATE ldap_user SET uid_number = $2 WHERE id = $1;
+
 -- name: DeleteLDAPUser :exec
 DELETE FROM ldap_user WHERE id = $1;
+
+-- name: ExistLDAPUserByUIDNumber :one
+SELECT EXISTS (SELECT 1 FROM ldap_user WHERE uid_number = $1) AS exists;

--- a/internal/setting/service.go
+++ b/internal/setting/service.go
@@ -52,6 +52,7 @@ type LDAPClient interface {
 type Querier interface {
 	GetUIDByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
 	CreateLDAPUser(ctx context.Context, params CreateLDAPUserParams) error
+	UpdateLDAPUser(ctx context.Context, params UpdateLDAPUserParams) error
 	DeleteLDAPUser(ctx context.Context, userID uuid.UUID) error
 	ExistByUserID(ctx context.Context, userID uuid.UUID) (bool, error)
 	GetPublicKeys(ctx context.Context, userID uuid.UUID) ([]PublicKey, error)
@@ -61,6 +62,7 @@ type Querier interface {
 	DeletePublicKey(ctx context.Context, id uuid.UUID) error
 	ExistByLinuxUsername(ctx context.Context, linuxUsername pgtype.Text) (bool, error)
 	GetAllUserInfoByUIDNumber(ctx context.Context, uidNumbers []int64) ([]GetAllUserInfoByUIDNumberRow, error)
+	ExistLDAPUserByUIDNumber(ctx context.Context, uidNumber int64) (bool, error)
 }
 
 type MembershipService interface {
@@ -606,4 +608,65 @@ func (s *Service) UpdatePassword(ctx context.Context, userID uuid.UUID, newPassw
 
 	logger.Info("user password updated successfully", zap.String("userID", userID.String()), zap.String("uid", uidString))
 	return nil
+}
+
+func (s *Service) BindLDAPUser(ctx context.Context, userID uuid.UUID, linuxUsername string) (LDAPUserInfo, error) {
+	traceCtx, span := s.tracer.Start(ctx, "BindLDAPUser")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, s.logger)
+
+	ldapInfo, err := s.ldapClient.GetUserInfo(linuxUsername)
+	if err != nil {
+		if errors.Is(err, ldaputil.ErrUserNotFound) {
+			logger.Warn("LDAP user not found", zap.String("linuxUsername", linuxUsername))
+			return LDAPUserInfo{}, err
+		}
+		logger.Error("failed to get LDAP user info by username", zap.String("linuxUsername", linuxUsername), zap.Error(err))
+		span.RecordError(err)
+		return LDAPUserInfo{}, err
+	}
+
+	uidNumberStr := ldapInfo.GetAttributeValue("uidNumber")
+	uidNumber, err := strconv.ParseInt(uidNumberStr, 10, 64)
+	if err != nil {
+		logger.Error("failed to parse uid number from LDAP user info", zap.String("uidNumberStr", uidNumberStr), zap.Error(err))
+		span.RecordError(err)
+		return LDAPUserInfo{}, fmt.Errorf("failed to parse uid number from LDAP user info: %w", err)
+	}
+
+	exists, err := s.query.ExistLDAPUserByUIDNumber(traceCtx, uidNumber)
+	if err != nil {
+		err = databaseutil.WrapDBErrorWithKeyValue(err, "ldap_user", "uid_number", fmt.Sprint(uidNumber), logger, "check LDAP user existence by uid number")
+		logger.Error("failed to check LDAP user existence by uid number", zap.Int64("uidNumber", uidNumber), zap.Error(err))
+		span.RecordError(err)
+		return LDAPUserInfo{}, err
+	}
+
+	if exists {
+		err = fmt.Errorf("%w with uid number %d already exists", internal.ErrLDAPUserAlreadyBound, uidNumber)
+		logger.Warn("LDAP user already bound to an application user", zap.String("linuxUsername", linuxUsername))
+		return LDAPUserInfo{}, err
+	}
+
+	err = s.query.UpdateLDAPUser(traceCtx, UpdateLDAPUserParams{
+		ID:        userID,
+		UidNumber: uidNumber,
+	})
+	if err != nil {
+		if errors.Is(err, databaseutil.ErrUniqueViolation) {
+			logger.Warn("ldap_user record already exists for user", zap.String("userID", userID.String()))
+			return LDAPUserInfo{}, internal.ErrDatabaseConflict
+		}
+		err = databaseutil.WrapDBErrorWithKeyValue(err, "ldap_user", "id", userID.String(), logger, "update ldap user")
+		logger.Error("failed to update ldap_user record", zap.String("userID", userID.String()), zap.Int64("uidNumber", uidNumber), zap.Error(err))
+		span.RecordError(err)
+		return LDAPUserInfo{}, err
+	}
+
+	logger.Info("successfully bound existing LDAP user to application user", zap.String("userID", userID.String()), zap.String("linuxUsername", linuxUsername))
+	return LDAPUserInfo{
+		UIDNumber: uidNumber,
+		Username:  linuxUsername,
+		PublicKey: ldapInfo.GetAttributeValues("sshPublicKey"),
+	}, nil
 }

--- a/internal/setting/service_test.go
+++ b/internal/setting/service_test.go
@@ -1,10 +1,12 @@
 package setting_test
 
 import (
+	"clustron-backend/internal"
 	ldaputil "clustron-backend/internal/ldap"
 	"clustron-backend/internal/setting"
 	"clustron-backend/internal/setting/mocks"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/go-ldap/ldap/v3"
@@ -719,6 +721,127 @@ func TestService_UpdatePassword(t *testing.T) {
 					t.Errorf("unexpected error: %v", err)
 				}
 			}
+		})
+	}
+}
+
+func TestService_BindLDAPUser(t *testing.T) {
+	testCase := []struct {
+		name           string
+		userID         uuid.UUID
+		ldapUIDNumber  int64
+		ldapEntry      *ldap.Entry
+		linuxUsername  string
+		setupMock      func(store *mocks.Querier, ldapClient *mocks.LDAPClient, userID uuid.UUID, linuxUsername string, ldapUIDNumber int64, entry *ldap.Entry)
+		expectedHasErr bool
+		expectedError  error
+	}{
+		{
+			name:          "Bind LDAP user successfully",
+			userID:        uuid.New(),
+			ldapUIDNumber: 10001,
+			ldapEntry: &ldap.Entry{
+				DN: "uid=testuser,ou=users,dc=example,dc=com",
+				Attributes: []*ldap.EntryAttribute{
+					{Name: "uidNumber", Values: []string{"10001"}},
+					{Name: "uid", Values: []string{"testuser"}},
+				},
+			},
+			linuxUsername: "testuser",
+			setupMock: func(store *mocks.Querier, ldapClient *mocks.LDAPClient, userID uuid.UUID, linuxUsername string, ldapUIDNumber int64, entry *ldap.Entry) {
+				ldapClient.On("GetUserInfo", linuxUsername).Return(entry, nil)
+				store.On("ExistLDAPUserByUIDNumber", mock.Anything, ldapUIDNumber).Return(false, nil)
+				store.On("UpdateLDAPUser", mock.Anything, setting.UpdateLDAPUserParams{
+					ID:        userID,
+					UidNumber: ldapUIDNumber,
+				}).Return(nil)
+			},
+			expectedHasErr: false,
+		},
+		{
+			name:          "Fail to bind LDAP user when user already bound",
+			userID:        uuid.New(),
+			ldapUIDNumber: 10001,
+			ldapEntry: &ldap.Entry{
+				DN: "uid=testuser,ou=users,dc=example,dc=com",
+				Attributes: []*ldap.EntryAttribute{
+					{Name: "uidNumber", Values: []string{"10001"}},
+					{Name: "uid", Values: []string{"testuser"}},
+				},
+			},
+			linuxUsername: "testuser",
+			setupMock: func(store *mocks.Querier, ldapClient *mocks.LDAPClient, userID uuid.UUID, linuxUsername string, ldapUIDNumber int64, entry *ldap.Entry) {
+				ldapClient.On("GetUserInfo", linuxUsername).Return(entry, nil)
+				store.On("ExistLDAPUserByUIDNumber", mock.Anything, ldapUIDNumber).Return(true, nil)
+			},
+			expectedHasErr: true,
+			expectedError:  internal.ErrLDAPUserAlreadyBound,
+		},
+		{
+			name:          "Fail to bind LDAP user when LDAP user not found",
+			userID:        uuid.New(),
+			ldapUIDNumber: 10001,
+			ldapEntry:     nil,
+			linuxUsername: "testuser",
+			setupMock: func(store *mocks.Querier, ldapClient *mocks.LDAPClient, userID uuid.UUID, linuxUsername string, ldapUIDNumber int64, entry *ldap.Entry) {
+				ldapClient.On("GetUserInfo", linuxUsername).Return(nil, ldaputil.ErrUserNotFound)
+			},
+			expectedHasErr: true,
+			expectedError:  ldaputil.ErrUserNotFound,
+		},
+		{
+			name:          "Fail to bind LDAP user when DB error occurs",
+			userID:        uuid.New(),
+			ldapUIDNumber: 10001,
+			ldapEntry: &ldap.Entry{
+				DN: "uid=testuser,ou=users,dc=example,dc=com",
+				Attributes: []*ldap.EntryAttribute{
+					{Name: "uidNumber", Values: []string{"10001"}},
+					{Name: "uid", Values: []string{"testuser"}},
+				},
+			},
+			linuxUsername: "testuser",
+			setupMock: func(store *mocks.Querier, ldapClient *mocks.LDAPClient, userID uuid.UUID, linuxUsername string, ldapUIDNumber int64, entry *ldap.Entry) {
+				ldapClient.On("GetUserInfo", linuxUsername).Return(entry, nil)
+				store.On("ExistLDAPUserByUIDNumber", mock.Anything, ldapUIDNumber).Return(false, nil)
+				store.On("UpdateLDAPUser", mock.Anything, setting.UpdateLDAPUserParams{
+					ID:        userID,
+					UidNumber: ldapUIDNumber,
+				}).Return(assert.AnError)
+			},
+			expectedHasErr: true,
+			expectedError:  assert.AnError,
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			querier := new(mocks.Querier)
+			userStore := new(mocks.UserStore)
+			ldapClient := new(mocks.LDAPClient)
+			service := setting.NewService(zaptest.NewLogger(t), querier, userStore, ldapClient)
+
+			if tc.setupMock != nil {
+				tc.setupMock(querier, ldapClient, tc.userID, tc.linuxUsername, tc.ldapUIDNumber, tc.ldapEntry)
+			}
+
+			ldapInfo, err := service.BindLDAPUser(context.Background(), tc.userID, tc.linuxUsername)
+			if tc.expectedHasErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				if !errors.Is(tc.expectedError, assert.AnError) && !errors.Is(err, tc.expectedError) {
+					t.Errorf("expected error %v, got %v", tc.expectedError, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if ldapInfo.Username != "testuser" {
+					t.Errorf("expected username 'testuser', got '%s'", ldapInfo.Username)
+				}
+			}
+
 		})
 	}
 }

--- a/internal/setting/type.go
+++ b/internal/setting/type.go
@@ -11,5 +11,3 @@ type LDAPPublicKey struct {
 	PublicKey   string
 	Title       string
 }
-
-type LinuxUsernameBlacklist map[string]struct{}

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -22,16 +22,17 @@ import (
 type Store interface {
 	UpdateFullName(ctx context.Context, userID uuid.UUID, fullName string) (User, error)
 	SearchByIdentifier(ctx context.Context, query string, page, size int) ([]string, int, error)
-	ListUsers(ctx context.Context, params ListUsersServiceParams) ([]ListUsersRow, int, error)
+	ListUsers(ctx context.Context, params ListUsersServiceParams) ([]ListUsersRowWithLinuxUsername, int, error)
 	UpdateRoleByID(ctx context.Context, id uuid.UUID, globalRole string) (User, error)
 }
 
 type Response struct {
-	ID        uuid.UUID `json:"id"`
-	Email     string    `json:"email"`
-	FullName  string    `json:"fullName"`
-	StudentID string    `json:"studentId"`
-	Role      string    `json:"role"`
+	ID            uuid.UUID `json:"id"`
+	Email         string    `json:"email"`
+	FullName      string    `json:"fullName"`
+	StudentID     string    `json:"studentId"`
+	LinuxUsername string    `json:"linuxUsername"`
+	Role          string    `json:"role"`
 }
 
 type UpdateFullNameRequest struct {
@@ -192,11 +193,12 @@ func (h *Handler) ListUserHandler(w http.ResponseWriter, r *http.Request) {
 	responseItems := make([]Response, len(items))
 	for i, item := range items {
 		responseItems[i] = Response{
-			ID:        item.ID,
-			FullName:  item.FullName.String,
-			Email:     item.Email,
-			StudentID: item.StudentID.String,
-			Role:      strings.ToUpper(item.Role),
+			ID:            item.ID,
+			FullName:      item.FullName.String,
+			Email:         item.Email,
+			StudentID:     item.StudentID.String,
+			LinuxUsername: item.LinuxUsername,
+			Role:          strings.ToUpper(item.Role),
 		}
 	}
 

--- a/internal/user/queries.sql
+++ b/internal/user/queries.sql
@@ -61,8 +61,9 @@ ORDER BY identifier
 LIMIT @Size OFFSET @Skip;
 
 -- name: ListUsers :many
-SELECT id, full_name, email, student_id, role
-FROM users
+SELECT u.id, u.full_name, u.email, u.student_id, u.role, lu.uid_number
+FROM users AS u
+JOIN ldap_user AS lu ON u.id = lu.id
 WHERE
     (sqlc.narg('search')::text IS NULL OR (email ILIKE '%' || sqlc.narg('search') || '%' OR student_id ILIKE '%' || sqlc.narg('search') || '%' OR full_name ILIKE '%' || sqlc.narg('search') || '%'))
   AND (sqlc.narg('role')::text IS NULL OR role = sqlc.narg('role'))

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -8,6 +8,7 @@ import (
 
 	databaseutil "github.com/NYCU-SDC/summer/pkg/database"
 	logutil "github.com/NYCU-SDC/summer/pkg/log"
+	"github.com/go-ldap/ldap/v3"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -16,25 +17,25 @@ import (
 	"go.uber.org/zap"
 )
 
+type LDAPClient interface {
+	GetUserInfoByUIDNumber(uidNumber int64) (*ldap.Entry, error)
+}
+
 type Service struct {
-	queries   *Queries
-	logger    *zap.Logger
-	presetMap map[string]config.PresetUserInfo
-	tracer    trace.Tracer
+	queries    *Queries
+	logger     *zap.Logger
+	presetMap  map[string]config.PresetUserInfo
+	tracer     trace.Tracer
+	ldapClient LDAPClient
 }
 
-type ServiceInterface interface {
-	GetByID(ctx context.Context, id uuid.UUID) (User, error)
-	GetIdByEmail(ctx context.Context, email string) (uuid.UUID, error)
-	GetIdByStudentId(ctx context.Context, studentID string) (uuid.UUID, error)
-}
-
-func NewService(logger *zap.Logger, presetMap map[string]config.PresetUserInfo, db DBTX) *Service {
+func NewService(logger *zap.Logger, presetMap map[string]config.PresetUserInfo, db DBTX, ldapClient LDAPClient) *Service {
 	return &Service{
-		queries:   New(db),
-		logger:    logger,
-		presetMap: presetMap,
-		tracer:    otel.Tracer("user/service"),
+		queries:    New(db),
+		logger:     logger,
+		presetMap:  presetMap,
+		ldapClient: ldapClient,
+		tracer:     otel.Tracer("user/service"),
 	}
 }
 
@@ -290,7 +291,7 @@ type ListUsersServiceParams struct {
 	Role   string
 }
 
-func (s *Service) ListUsers(ctx context.Context, params ListUsersServiceParams) ([]ListUsersRow, int, error) {
+func (s *Service) ListUsers(ctx context.Context, params ListUsersServiceParams) ([]ListUsersRowWithLinuxUsername, int, error) {
 	traceCtx, span := s.tracer.Start(ctx, "ListUsers")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -322,7 +323,20 @@ func (s *Service) ListUsers(ctx context.Context, params ListUsersServiceParams) 
 		return nil, 0, err
 	}
 
-	return items, int(totalCount), nil
+	var res = make([]ListUsersRowWithLinuxUsername, len(items))
+	for i, item := range items {
+		ldapInfo, err := s.ldapClient.GetUserInfoByUIDNumber(item.UidNumber)
+		if err != nil {
+			logger.Warn("Failed to get LDAP info for user", zap.String("userID", item.ID.String()), zap.Int64("uidNumber", item.UidNumber), zap.Error(err))
+			continue
+		}
+		res[i] = ListUsersRowWithLinuxUsername{
+			ListUsersRow:  item,
+			LinuxUsername: ldapInfo.GetAttributeValue("uid"),
+		}
+	}
+
+	return res, int(totalCount), nil
 }
 
 func (s *Service) HasAdmin(ctx context.Context) (bool, error) {

--- a/internal/user/type.go
+++ b/internal/user/type.go
@@ -1,0 +1,6 @@
+package user
+
+type ListUsersRowWithLinuxUsername struct {
+	ListUsersRow
+	LinuxUsername string
+}

--- a/internal/validator.go
+++ b/internal/validator.go
@@ -1,14 +1,85 @@
 package internal
 
 import (
+	"bufio"
+	"os"
 	"regexp"
+	"strings"
 
 	"github.com/go-playground/validator/v10"
 )
 
+var LinuxUserBlacklist = map[string]struct{}{
+	// Core System Users
+	"root":          {},
+	"daemon":        {},
+	"bin":           {},
+	"sys":           {},
+	"sync":          {},
+	"games":         {},
+	"man":           {},
+	"lp":            {},
+	"mail":          {},
+	"news":          {},
+	"uucp":          {},
+	"proxy":         {},
+	"admin":         {},
+	"administrator": {},
+
+	// Service-Specific Accounts
+	"syslog":     {},
+	"www-data":   {},
+	"backup":     {},
+	"list":       {},
+	"irc":        {},
+	"gnats":      {},
+	"nobody":     {},
+	"nogroup":    {},
+	"messagebus": {},
+	"sshd":       {},
+
+	// Modern Systemd / Virtual Users
+	"systemd-network":  {},
+	"systemd-resolve":  {},
+	"systemd-timesync": {},
+	"systemd-coredump": {},
+	"_apt":             {},
+	"uuidd":            {},
+	"tcpdump":          {},
+
+	// Database and Common App Defaults
+	"mysql":    {},
+	"postgres": {},
+	"apache":   {},
+	"nginx":    {},
+	"postfix":  {},
+
+	// suggested system name
+	"dhcpcd":        {},
+	"pollinate":     {},
+	"polkitd":       {},
+	"tss":           {},
+	"landscape":     {},
+	"fwupd-refresh": {},
+	"usbmux":        {},
+	"sssd":          {},
+}
+
 func NewValidator() *validator.Validate {
 	v := validator.New()
-	err := v.RegisterValidation("regexp", validateRegex)
+	err := loadSystemUsers()
+	if err != nil {
+		panic(err)
+	}
+	err = v.RegisterValidation("regexp", validateRegex)
+	if err != nil {
+		panic(err)
+	}
+	err = v.RegisterValidation("linux_username_format", validateLinuxUsernameFormat)
+	if err != nil {
+		panic(err)
+	}
+	err = v.RegisterValidation("linux_username_blacklist", validateLinuxUsernameBlacklist)
 	if err != nil {
 		panic(err)
 	}
@@ -25,4 +96,58 @@ func validateRegex(fl validator.FieldLevel) bool {
 		return false
 	}
 	return matched
+}
+
+func validateLinuxUsernameFormat(fl validator.FieldLevel) bool {
+	value := fl.Field().String()
+
+	pattern := `^[a-z_][a-z0-9_-]*[$]?$`
+	matched, err := regexp.MatchString(pattern, value)
+	if err != nil {
+		return false
+	}
+
+	return matched
+}
+
+func validateLinuxUsernameBlacklist(fl validator.FieldLevel) bool {
+	value := fl.Field().String()
+	if _, exists := LinuxUserBlacklist[value]; exists {
+		return false
+	}
+	return true
+}
+
+func loadSystemUsers() error {
+	file, err := os.Open("/etc/passwd")
+	if err != nil {
+		return err
+	}
+	defer func(file *os.File) {
+		closeErr := file.Close()
+		if err != nil {
+			err = closeErr
+		}
+	}(file)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip empty lines or comments
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+
+		// /etc/passwd format: name:password:UID:GID:comment:home:shell
+		parts := strings.Split(line, ":")
+		if len(parts) > 0 {
+			username := strings.ToLower(strings.TrimSpace(parts[0]))
+			if username != "" {
+				LinuxUserBlacklist[username] = struct{}{}
+			}
+		}
+	}
+
+	return scanner.Err()
 }


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add `PUT /api/users/{id}/ldapBind` for binding user to another LDAP user.
- Add `linux_username_format` and `linux_username_blacklist` to validator for validate the linux username in requests.

## Additional Information
- Reorder the error handling in `internal/error.go`
- Move `LinuxBlacklist` from `settings/handler.go` to `internal/validator.go`
- Add testing to service and handler layer for test binding user