### PR TITLE
[CLUST-304] Migrate mockery v2 to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+env:
+  GO_VERSION: '1.24'
+  SQLC_VERSION: '1.28.0'
+  MOCKERY_VERSION: '3.7.0'
+
 jobs:
   Lint:
     runs-on:  ubuntu-latest
@@ -15,17 +20,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.28.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Build
         run: |
@@ -47,17 +52,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.28.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Test
         run: make test
@@ -72,17 +77,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.25.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Build
         run: |
@@ -57,7 +57,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Test
         run: make test
@@ -82,7 +82,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Build
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Build
         run: |
@@ -56,7 +56,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Test
         run: make test
@@ -81,7 +81,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Build
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+env:
+  GO_VERSION: '1.24'
+  SQLC_VERSION: '1.28.0'
+  MOCKERY_VERSION: '3.7.0'
+
 jobs:
   Lint:
     runs-on:  ubuntu-latest
@@ -15,17 +20,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.28.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Build
         run: |
@@ -46,17 +51,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.28.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Test
         run: make test
@@ -71,17 +76,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.25.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Build
         run: |

--- a/.github/workflows/push-commit.yml
+++ b/.github/workflows/push-commit.yml
@@ -5,6 +5,11 @@ on:
     branches-ignore:
       - main
 
+env:
+  GO_VERSION: '1.24'
+  SQLC_VERSION: '1.28.0'
+  MOCKERY_VERSION: '3.7.0'
+
 jobs:
   check-if-in-pr:
     runs-on: ubuntu-latest
@@ -36,17 +41,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-            go-version: '1.24'
+            go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.28.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Build
         run: |
@@ -69,17 +74,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.28.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Test
         run: make test
@@ -95,17 +100,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-            go-version: '1.24'
+            go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.25.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Build
         run: |

--- a/.github/workflows/push-commit.yml
+++ b/.github/workflows/push-commit.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Build
         run: |
@@ -79,7 +79,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Test
         run: make test
@@ -105,7 +105,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-            mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Build
         run: |

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
 
+env:
+  GO_VERSION: '1.24'
+  SQLC_VERSION: '1.28.0'
+  MOCKERY_VERSION: '3.7.0'
+
 jobs:
   Lint:
     runs-on:  ubuntu-latest
@@ -15,17 +20,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.28.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Build
         run: |
@@ -47,17 +52,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.28.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Test
         run: make test
@@ -72,17 +77,17 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.25.0'
+          sqlc-version: ${{ env.SQLC_VERSION }}
 
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '3.7.0'
+          mockery-version: ${{ env.MOCKERY_VERSION }}
 
       - name: Build
         run: |

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Build
         run: |
@@ -57,7 +57,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Test
         run: make test
@@ -82,7 +82,7 @@ jobs:
       - name: Setup mockery
         uses: brokeyourbike/go-mockery-action@v0
         with:
-          mockery-version: '2.53.3'
+          mockery-version: '3.7.0'
 
       - name: Build
         run: |

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,0 +1,13 @@
+dir: "{{.InterfaceDir}}/mocks"
+pkgname: "mocks"
+filename: "{{.InterfaceName}}.go"
+structname: "{{.InterfaceName}}"
+template: testify
+exclude-subpkg-regex:
+  - "mocks"
+
+packages:
+  clustron-backend/internal:
+    config:
+      recursive: true
+

--- a/Makefile
+++ b/Makefile
@@ -49,5 +49,5 @@ gen:
 	@echo -e "  -> Generating Casbin Policyfile..."
 	@./scripts/create_full_policy.sh || (echo -e "  -> $(RED)Policyfile generation failed$(NC)" && exit 1)
 	@echo -e "  -> Running go generate..."
-	@go generate ./... || (echo -e "  -> $(RED)Go generate failed$(NC)" && exit 1)
+	@mockery
 	@echo -e "==> $(BLUE)Generation completed$(NC)"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ make -v
 If the result is something like `make command not found`, install `make` before running the above command.
 
 ### Install other tools
-We use [sqlc](https://sqlc.dev) for database queries generation and [mockery](https://vektra.github.io/mockery/latest/) for mocking.
+We use [sqlc](https://sqlc.dev) for database queries generation and [mockery](https://vektra.github.io/mockery/latest/) for mocking. 
+Please make sure your mockery version is v3.7.0, otherwise the generated mock code will not work with our codebase.
 
 #### MacOS
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ brew upgrade mockery
 #### Go install 
 ```
 go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
-go install github.com/vektra/mockery/v3@v3.2.2      # not recommanded by the documentation
+go install github.com/vektra/mockery/v3@v3.7.0
 ```
 
 You can also find more OS-spacific installing methods from the documentation.

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -146,11 +146,12 @@ func main() {
 
 	// Querier
 	settingQuerier := setting.New(dbPool)
+	jwtQuerier := jwt.New(dbPool)
 
 	// Service
 	redisService := redis.NewService(logger, cfg.RedisURL)
 	userService := user.NewService(logger, cfg.PresetUser, dbPool)
-	jwtService := jwt.NewService(logger, cfg.Secret, cfg.OAuthProxySecret, 15*time.Minute, 24*time.Hour, dbPool)
+	jwtService := jwt.NewService(logger, cfg.Secret, cfg.OAuthProxySecret, 15*time.Minute, 24*time.Hour, jwtQuerier)
 	authService := auth.NewService(logger, dbPool, userService, 15*time.Minute, cfg.PresetUser)
 	settingService := setting.NewService(logger, settingQuerier, userService, ldapClient)
 	ldapGroupService := ldapgroup.NewService(logger, dbPool)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate mockery --name CasbinEnforcer
+//mockery:generate: true
 type CasbinEnforcer interface {
 	Enforce(role, path, method string) (bool, error)
 }

--- a/internal/group/handler.go
+++ b/internal/group/handler.go
@@ -18,7 +18,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate mockery --name=MemberStore
+//mockery:generate: true
 type MemberStore interface {
 	Add(ctx context.Context, groupId uuid.UUID, memberIdentifier string, role uuid.UUID) (membership.JoinResult, error)
 	Join(ctx context.Context, userId uuid.UUID, groupId uuid.UUID, role uuid.UUID, isArchived bool) (membership.MemberResponse, error)
@@ -26,7 +26,7 @@ type MemberStore interface {
 	Update(ctx context.Context, groupID uuid.UUID, userID uuid.UUID, role uuid.UUID) (membership.MemberResponse, error)
 }
 
-//go:generate mockery --name=Store
+//mockery:generate: true
 type Store interface {
 	ListWithUserScope(ctx context.Context, user jwt.User, page int, size int, sort string, sortBy string) ([]grouprole.UserScope, int /* totalCount */, error)
 	ListByIDWithLinks(ctx context.Context, user jwt.User, groupID uuid.UUID) (ResponseWithLinks, error)

--- a/internal/grouprole/handler.go
+++ b/internal/grouprole/handler.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate mockery --name=Store
+//mockery:generate: true
 type Store interface {
 	GetAll(ctx context.Context) ([]GroupRole, error)
 	Create(ctx context.Context, roleName string, level AccessLevel) (GroupRole, error)

--- a/internal/jwt/handler.go
+++ b/internal/jwt/handler.go
@@ -2,6 +2,8 @@ package jwt
 
 import (
 	"context"
+	"net/http"
+
 	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
 	logutil "github.com/NYCU-SDC/summer/pkg/log"
 	"github.com/NYCU-SDC/summer/pkg/problem"
@@ -10,10 +12,9 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"net/http"
 )
 
-//go:generate mockery --name JWTIssuer
+//mockery:generate: true
 type JWTIssuer interface {
 	New(ctx context.Context, user User) (string, error)
 	GetUserByRefreshToken(ctx context.Context, refreshToken uuid.UUID) (User, error)

--- a/internal/jwt/service.go
+++ b/internal/jwt/service.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	databaseutil "github.com/NYCU-SDC/summer/pkg/database"
 	logutil "github.com/NYCU-SDC/summer/pkg/log"
 	"github.com/google/uuid"
@@ -12,13 +15,21 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"strings"
-	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
 const Issuer = "clustron"
+
+//mockery:generate: true
+type Querier interface {
+	GetByID(ctx context.Context, id uuid.UUID) (RefreshToken, error)
+	GetUserByRefreshToken(ctx context.Context, id uuid.UUID) (User, error)
+	Create(ctx context.Context, arg CreateParams) (RefreshToken, error)
+	Inactivate(ctx context.Context, id uuid.UUID) (RefreshToken, error)
+	InactivateByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
+	DeleteExpired(ctx context.Context) (int64, error)
+}
 
 type Service struct {
 	logger                 *zap.Logger
@@ -27,10 +38,10 @@ type Service struct {
 	expiration             time.Duration
 	refreshTokenExpiration time.Duration
 	tracer                 trace.Tracer
-	queries                *Queries
+	queries                Querier
 }
 
-func NewService(logger *zap.Logger, secret string, oauthProxySecret string, expiration, refreshTokenExpiration time.Duration, db DBTX) *Service {
+func NewService(logger *zap.Logger, secret string, oauthProxySecret string, expiration, refreshTokenExpiration time.Duration, queries Querier) *Service {
 	return &Service{
 		logger:                 logger,
 		secret:                 secret,
@@ -38,7 +49,7 @@ func NewService(logger *zap.Logger, secret string, oauthProxySecret string, expi
 		expiration:             expiration,
 		refreshTokenExpiration: refreshTokenExpiration,
 		tracer:                 otel.Tracer("jwt/service"),
-		queries:                New(db),
+		queries:                queries,
 	}
 }
 

--- a/internal/jwt/service_test.go
+++ b/internal/jwt/service_test.go
@@ -4,49 +4,16 @@ import (
 	"clustron-backend/internal/jwt"
 	"clustron-backend/internal/jwt/mocks"
 	"context"
-	"github.com/jackc/pgx/v5/pgtype"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 )
-
-// generate the db mock using mockery
-//go:generate mockery --name=DBTX
-
-// mockRow is a minimal mock for pgx.Row
-// It implements Scan to set the expected values
-
-type mockRow struct {
-	mock.Mock
-	vals []interface{}
-	err  error
-}
-
-func (m *mockRow) Scan(dest ...interface{}) error {
-	for i := range dest {
-		if i < len(m.vals) {
-			switch d := dest[i].(type) {
-			case *uuid.UUID:
-				*d = m.vals[i].(uuid.UUID)
-			case *pgtype.Bool:
-				*d = m.vals[i].(pgtype.Bool)
-			case *pgtype.Timestamptz:
-				*d = m.vals[i].(pgtype.Timestamptz)
-			case *string:
-				*d = m.vals[i].(string)
-			case *pgtype.Text:
-				*d = m.vals[i].(pgtype.Text)
-			case *pgtype.Int4:
-				*d = m.vals[i].(pgtype.Int4)
-			}
-		}
-	}
-	return m.err
-}
 
 func TestService_NewAndParseToken(t *testing.T) {
 	logger := zap.NewNop()
@@ -75,8 +42,8 @@ func TestService_Parse_InvalidToken(t *testing.T) {
 func TestService_GetUserByRefreshToken(t *testing.T) {
 	logger := zap.NewNop()
 	secret := "test-secret"
-	mockDB := new(mocks.DBTX)
-	s := jwt.NewService(logger, secret, "oauth-secret", time.Minute, time.Hour, mockDB)
+	querier := mocks.NewQuerier(t)
+	s := jwt.NewService(logger, secret, "oauth-secret", time.Minute, time.Hour, querier)
 
 	id := uuid.New()
 	user := jwt.User{ID: id, Email: "test@example.com", Role: "user", StudentID: pgtype.Text{String: "123", Valid: true}}
@@ -97,11 +64,8 @@ func TestService_GetUserByRefreshToken(t *testing.T) {
 			expired:      false,
 			expectErr:    false,
 			setupMock: func() {
-				mockDB.ExpectedCalls = nil
-				refreshRow := &mockRow{vals: []interface{}{id, id, pgtype.Bool{Bool: true, Valid: true}, pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true}}, err: nil}
-				mockDB.On("QueryRow", mock.Anything, "-- name: GetByID :one\nSELECT id, user_id, is_active, expiration_date FROM refresh_tokens WHERE id = $1\n", id).Return(refreshRow)
-				userRow := &mockRow{vals: []interface{}{user.ID, user.Email, user.Role, user.FullName, user.StudentID, user.CreatedAt, user.UpdatedAt}, err: nil}
-				mockDB.On("QueryRow", mock.Anything, "-- name: GetUserByRefreshToken :one\nSELECT u.id, u.email, u.role, u.full_name, u.student_id, u.created_at, u.updated_at FROM refresh_tokens r JOIN users u ON r.user_id = u.id WHERE r.id = $1\n", id).Return(userRow).Once()
+				querier.On("GetByID", mock.Anything, id).Return(jwt.RefreshToken{ID: id, UserID: id, IsActive: pgtype.Bool{Bool: true, Valid: true}, ExpirationDate: pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true}}, nil).Once()
+				querier.On("GetUserByRefreshToken", mock.Anything, id).Return(jwt.User{ID: user.ID, Email: user.Email, Role: user.Role, StudentID: user.StudentID}, nil).Once()
 			},
 		},
 		{
@@ -112,9 +76,7 @@ func TestService_GetUserByRefreshToken(t *testing.T) {
 			expectErr:    true,
 			errContains:  "refresh token expired",
 			setupMock: func() {
-				mockDB.ExpectedCalls = nil
-				refreshRow := &mockRow{vals: []interface{}{id, id, pgtype.Bool{Bool: true, Valid: true}, pgtype.Timestamptz{Time: time.Now().Add(-time.Hour), Valid: true}}, err: nil}
-				mockDB.On("QueryRow", mock.Anything, "-- name: GetByID :one\nSELECT id, user_id, is_active, expiration_date FROM refresh_tokens WHERE id = $1\n", id).Return(refreshRow)
+				querier.On("GetByID", mock.Anything, id).Return(jwt.RefreshToken{ID: id, UserID: id, IsActive: pgtype.Bool{Bool: true, Valid: true}, ExpirationDate: pgtype.Timestamptz{Time: time.Now().Add(-time.Hour), Valid: true}}, nil).Once()
 			},
 		},
 	}

--- a/internal/ldap/client.go
+++ b/internal/ldap/client.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate mockery --name=LDAPClient
+//mockery:generate: true
 type LDAPClient interface {
 	CreateGroup(groupName, gidNumber string, memberUids []string) error
 	DeleteGroup(groupName string) error

--- a/internal/membership/handler.go
+++ b/internal/membership/handler.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate mockery --name=Store
+//mockery:generate: true
 type Store interface {
 	Add(ctx context.Context, groupId uuid.UUID, memberIdentifier string, role uuid.UUID) (JoinResult, error)
 	Remove(ctx context.Context, groupID uuid.UUID, userID uuid.UUID) error
@@ -29,7 +29,7 @@ type Store interface {
 	CountPendingByGroupID(ctx context.Context, groupID uuid.UUID) (int64, error)
 }
 
-//go:generate mockery --name=UserService
+//mockery:generate: true
 type UserService interface {
 	GetIdByEmail(ctx context.Context, email string) (uuid.UUID, error)
 	GetIdByStudentId(ctx context.Context, studentID string) (uuid.UUID, error)

--- a/internal/membership/service.go
+++ b/internal/membership/service.go
@@ -27,13 +27,13 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate mockery --name GroupRoleStore
+//mockery:generate: true
 type GroupRoleStore interface {
 	GetByID(ctx context.Context, id uuid.UUID) (grouprole.GroupRole, error)
 	GetByUser(ctx context.Context, userID uuid.UUID, groupID uuid.UUID) (grouprole.GroupRole, error)
 }
 
-//go:generate mockery --name UserStore
+//mockery:generate: true
 type UserStore interface {
 	GetByID(ctx context.Context, id uuid.UUID) (user.User, error)
 	GetIdByEmail(ctx context.Context, email string) (uuid.UUID, error)
@@ -41,7 +41,7 @@ type UserStore interface {
 	ExistsByIdentifier(ctx context.Context, identifier string) (bool, error)
 }
 
-//go:generate mockery --name SettingStore
+//mockery:generate: true
 type SettingStore interface {
 	GetLDAPUserInfoByUserID(ctx context.Context, userID uuid.UUID) (setting.LDAPUserInfo, error)
 	GetAllUserByUIDNumbers(ctx context.Context, uidNumbers []int64) (map[int64]setting.User, error)

--- a/internal/setting/handler.go
+++ b/internal/setting/handler.go
@@ -60,7 +60,7 @@ type UpdatePasswordRequest struct {
 	NewPassword string `json:"newPassword" validate:"required,min=8"`
 }
 
-//go:generate mockery --name Store
+//mockery:generate: true
 type Store interface {
 	GetLDAPUserInfoByUserID(ctx context.Context, userID uuid.UUID) (LDAPUserInfo, error)
 	GetPublicKeysByUserID(ctx context.Context, userID uuid.UUID) ([]LDAPPublicKey, error)

--- a/internal/setting/service.go
+++ b/internal/setting/service.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate mockery --name UserStore
+//mockery:generate: true
 type UserStore interface {
 	GetByID(ctx context.Context, userID uuid.UUID) (user.User, error)
 	SetupUserRole(ctx context.Context, userID uuid.UUID) (string, error)
@@ -34,7 +34,7 @@ type UserStore interface {
 	ListLoginMethodsByID(ctx context.Context, userID uuid.UUID) ([]user.ListLoginMethodsRow, error)
 }
 
-//go:generate mockery --name LDAPClient
+//mockery:generate: true
 type LDAPClient interface {
 	CreateUser(uid string, cn string, sn string, sshPublicKey string, uidNumber string) error
 	DeleteUser(uid string) error
@@ -48,7 +48,7 @@ type LDAPClient interface {
 	UpdateUserPassword(uid string, password string) error
 }
 
-//go:generate mockery --name Querier
+//mockery:generate: true
 type Querier interface {
 	GetUIDByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
 	CreateLDAPUser(ctx context.Context, params CreateLDAPUserParams) error

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -18,7 +18,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate mockery --name=Store
+//mockery:generate: true
 type Store interface {
 	UpdateFullName(ctx context.Context, userID uuid.UUID, fullName string) (User, error)
 	SearchByIdentifier(ctx context.Context, query string, page, size int) ([]string, int, error)


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Upgrade mockery to `v3.7.0`.

## Additional Information
- Revise the mock interface in `jwt/service_test` to `Querier`.
- Add mockery version note in `README.md`.