### PR TITLE
[CLUST-286] Make LDAP user and group DN configurable

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,3 +22,11 @@ preset_user:
   'YOUR_EMAIL':
     role: admin
 enable_internal_login: false # Set to true if you are in the testing phase.
+ldap:
+  ldap_host: "localhost"
+  ldap_port: "389"
+  ldap_base_dn: "dc=clustron,dc=example,dc=com"
+  ldap_user_dn: "ou=People,dc=clustron,dc=example,dc=com"
+  ldap_group_dn: "ou=Groups,dc=clustron,dc=example,dc=com"
+  ldap_bind_dn: "cn=admin,dc=clustron,dc=example,dc=com"
+  ldap_bind_pwd: "admin"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,6 +247,8 @@ func FromEnv(config *Config, logger *LogBuffer) (*Config, error) {
 			LDAPHost:    os.Getenv("LDAP_HOST"),
 			LDAPPort:    os.Getenv("LDAP_PORT"),
 			LDAPBaseDN:  os.Getenv("LDAP_BASE_DN"),
+			LDAPUserDN:  os.Getenv("LDAP_USER_DN"),
+			LDAPGroupDN: os.Getenv("LDAP_GROUP_DN"),
 			LDAPBindDN:  os.Getenv("LDAP_BIND_DN"),
 			LDAPBindPwd: os.Getenv("LDAP_BIND_PWD"),
 		},
@@ -282,6 +284,13 @@ func FromFlags(config *Config) (*Config, error) {
 	flag.StringVar(&flagConfig.NYCUOauthClientID, "nycu_oauth_client_id", "", "NYCU OAuth client ID")
 	flag.StringVar(&flagConfig.NYCUOauthClientSecret, "nycu_oauth_client_secret", "", "NYCU OAuth client secret")
 	flag.BoolVar(&flagConfig.EnableInternalLogin, "enable_internal_login", false, "enable internal login")
+	flag.StringVar(&flagConfig.LDAP.LDAPHost, "ldap_host", "", "ldap host")
+	flag.StringVar(&flagConfig.LDAP.LDAPPort, "ldap_port", "", "ldap port")
+	flag.StringVar(&flagConfig.LDAP.LDAPBaseDN, "ldap_base_dn", "", "ldap base dn")
+	flag.StringVar(&flagConfig.LDAP.LDAPUserDN, "ldap_user_dn", "", "ldap user dn")
+	flag.StringVar(&flagConfig.LDAP.LDAPGroupDN, "ldap_group_dn", "", "ldap group dn")
+	flag.StringVar(&flagConfig.LDAP.LDAPBindDN, "ldap_bind_dn", "", "ldap bind dn")
+	flag.StringVar(&flagConfig.LDAP.LDAPBindPwd, "ldap_bind_pwd", "", "ldap bind password")
 
 	flag.Parse()
 

--- a/internal/ldap/client.go
+++ b/internal/ldap/client.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-ldap/ldap/v3"
 	"go.uber.org/zap"
@@ -55,6 +56,22 @@ func (c *Client) Close() {
 	}
 }
 
+func (c *Client) userBaseDN() string {
+	if strings.TrimSpace(c.Config.LDAPUserDN) != "" {
+		return c.Config.LDAPUserDN
+	}
+
+	return "ou=People," + c.Config.LDAPBaseDN
+}
+
+func (c *Client) groupBaseDN() string {
+	if strings.TrimSpace(c.Config.LDAPGroupDN) != "" {
+		return c.Config.LDAPGroupDN
+	}
+
+	return "ou=Groups," + c.Config.LDAPBaseDN
+}
+
 func (c *Client) Validate() error {
 	// Check if base DN exists
 	searchRequest := ldap.NewSearchRequest(
@@ -76,37 +93,37 @@ func (c *Client) Validate() error {
 	}
 
 	searchPeopleOURequest := ldap.NewSearchRequest(
-		fmt.Sprintf("ou=People,%s", c.Config.LDAPBaseDN),
+		c.userBaseDN(),
 		ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
-		"(objectClass=organizationalUnit)",
+		"(objectClass=*)",
 		[]string{"dn"},
 		nil,
 	)
 	sr, err = c.Conn.Search(searchPeopleOURequest)
 	if err != nil {
-		c.Logger.Error("Failed to search for People OU", zap.Error(err))
-		return fmt.Errorf("failed to search for People OU: %w", err)
+		c.Logger.Error("Failed to search for LDAP user DN", zap.String("userDN", c.userBaseDN()), zap.Error(err))
+		return fmt.Errorf("failed to search for LDAP user DN: %w", err)
 	}
 	if len(sr.Entries) == 0 {
-		c.Logger.Error("People OU does not exist in LDAP", zap.String("baseDN", c.Config.LDAPBaseDN))
-		return fmt.Errorf("people OU does not exist in LDAP: %s", c.Config.LDAPBaseDN)
+		c.Logger.Error("LDAP user DN does not exist in LDAP", zap.String("userDN", c.userBaseDN()))
+		return fmt.Errorf("LDAP user DN does not exist in LDAP: %s", c.userBaseDN())
 	}
 
 	searchGroupsOURequest := ldap.NewSearchRequest(
-		fmt.Sprintf("ou=Groups,%s", c.Config.LDAPBaseDN),
+		c.groupBaseDN(),
 		ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
-		"(objectClass=organizationalUnit)",
+		"(objectClass=*)",
 		[]string{"dn"},
 		nil,
 	)
 	sr, err = c.Conn.Search(searchGroupsOURequest)
 	if err != nil {
-		c.Logger.Error("Failed to search for Groups OU", zap.Error(err))
-		return fmt.Errorf("failed to search for Groups OU: %w", err)
+		c.Logger.Error("Failed to search for LDAP group DN", zap.String("groupDN", c.groupBaseDN()), zap.Error(err))
+		return fmt.Errorf("failed to search for LDAP group DN: %w", err)
 	}
 	if len(sr.Entries) == 0 {
-		c.Logger.Error("Groups OU does not exist in LDAP", zap.String("baseDN", c.Config.LDAPBaseDN))
-		return fmt.Errorf("groups OU does not exist in LDAP: %s", c.Config.LDAPBaseDN)
+		c.Logger.Error("LDAP group DN does not exist in LDAP", zap.String("groupDN", c.groupBaseDN()))
+		return fmt.Errorf("LDAP group DN does not exist in LDAP: %s", c.groupBaseDN())
 	}
 
 	c.Logger.Info("LDAP structure validated successfully")

--- a/internal/ldap/client_test.go
+++ b/internal/ldap/client_test.go
@@ -1,0 +1,81 @@
+package ldap
+
+import (
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_Validate(t *testing.T) {
+	t.Run("Should validate default People and Groups DNs", func(t *testing.T) {
+		client, done := newTestClient(t)
+		defer done()
+
+		require.NoError(t, client.Validate())
+	})
+
+	t.Run("Should validate configured user and group DNs", func(t *testing.T) {
+		userDN := "ou=ClustronUsers,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
+		groupDN := "ou=ClustronGroups,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
+
+		client, done := newTestClientWithDNs(t, userDN, groupDN)
+		defer done()
+
+		require.NoError(t, client.Validate())
+	})
+
+	t.Run("Should return error when configured user DN does not exist", func(t *testing.T) {
+		userDN := "ou=MissingUsers,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
+		groupDN := "ou=ClustronGroups,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
+
+		client, done := newTestClientWithDNs(t, "", groupDN)
+		defer done()
+
+		client.Config.LDAPUserDN = userDN
+
+		err := client.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to search for LDAP user DN")
+	})
+}
+
+func TestClient_UsesConfiguredUserAndGroupDNs(t *testing.T) {
+	userDN := "ou=ClustronUsers,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
+	groupDN := "ou=ClustronGroups,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
+
+	client, done := newTestClientWithDNs(t, userDN, groupDN)
+	defer done()
+
+	setupUser(t, client, user1, "CN1", "SN1", "ssh-rsa AAAA1", "10001")
+	setupGroup(t, client, groupName, gidNumber, []string{user1})
+
+	userEntry, err := client.GetUserInfo(user1)
+	require.NoError(t, err)
+	assert.Equal(t, "uid="+user1+","+userDN, userEntry.DN)
+
+	groupEntry, err := client.GetGroupInfo(groupName)
+	require.NoError(t, err)
+	assert.Equal(t, "cn="+groupName+","+groupDN, groupEntry.DN)
+
+	rawUserEntry, err := client.Conn.Search(ldap.NewSearchRequest(
+		userDN,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		"(uid="+user1+")",
+		[]string{"dn"},
+		nil,
+	))
+	require.NoError(t, err)
+	require.Len(t, rawUserEntry.Entries, 1)
+
+	rawGroupEntry, err := client.Conn.Search(ldap.NewSearchRequest(
+		groupDN,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		"(cn="+groupName+")",
+		[]string{"dn"},
+		nil,
+	))
+	require.NoError(t, err)
+	require.Len(t, rawGroupEntry.Entries, 1)
+}

--- a/internal/ldap/client_test.go
+++ b/internal/ldap/client_test.go
@@ -9,73 +9,99 @@ import (
 )
 
 func TestClient_Validate(t *testing.T) {
-	t.Run("Should validate default People and Groups DNs", func(t *testing.T) {
-		client, done := newTestClient(t)
-		defer done()
+	tests := []struct {
+		name           string
+		userDN         string
+		groupDN        string
+		overrideUserDN string
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name: "Should validate default People and Groups DNs",
+		},
+		{
+			name:    "Should validate configured user and group DNs",
+			userDN:  "ou=ClustronUsers,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club",
+			groupDN: "ou=ClustronGroups,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club",
+		},
+		{
+			name:           "Should return error when configured user DN does not exist",
+			groupDN:        "ou=ClustronGroups,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club",
+			overrideUserDN: "ou=MissingUsers,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club",
+			wantErr:        true,
+			errContains:    "failed to search for LDAP user DN",
+		},
+	}
 
-		require.NoError(t, client.Validate())
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, done := newTestClientWithDNs(t, tc.userDN, tc.groupDN)
+			defer done()
 
-	t.Run("Should validate configured user and group DNs", func(t *testing.T) {
-		userDN := "ou=ClustronUsers,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
-		groupDN := "ou=ClustronGroups,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
+			if tc.overrideUserDN != "" {
+				client.Config.LDAPUserDN = tc.overrideUserDN
+			}
 
-		client, done := newTestClientWithDNs(t, userDN, groupDN)
-		defer done()
-
-		require.NoError(t, client.Validate())
-	})
-
-	t.Run("Should return error when configured user DN does not exist", func(t *testing.T) {
-		userDN := "ou=MissingUsers,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
-		groupDN := "ou=ClustronGroups,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
-
-		client, done := newTestClientWithDNs(t, "", groupDN)
-		defer done()
-
-		client.Config.LDAPUserDN = userDN
-
-		err := client.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to search for LDAP user DN")
-	})
+			err := client.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestClient_UsesConfiguredUserAndGroupDNs(t *testing.T) {
-	userDN := "ou=ClustronUsers,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
-	groupDN := "ou=ClustronGroups,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club"
+	tests := []struct {
+		name    string
+		userDN  string
+		groupDN string
+	}{
+		{
+			name:    "Should store users and groups under configured DNs",
+			userDN:  "ou=ClustronUsers,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club",
+			groupDN: "ou=ClustronGroups,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club",
+		},
+	}
 
-	client, done := newTestClientWithDNs(t, userDN, groupDN)
-	defer done()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, done := newTestClientWithDNs(t, tc.userDN, tc.groupDN)
+			defer done()
 
-	setupUser(t, client, user1, "CN1", "SN1", "ssh-rsa AAAA1", "10001")
-	setupGroup(t, client, groupName, gidNumber, []string{user1})
+			setupUser(t, client, user1, "CN1", "SN1", "ssh-rsa AAAA1", "10001")
+			setupGroup(t, client, groupName, gidNumber, []string{user1})
 
-	userEntry, err := client.GetUserInfo(user1)
-	require.NoError(t, err)
-	assert.Equal(t, "uid="+user1+","+userDN, userEntry.DN)
+			userEntry, err := client.GetUserInfo(user1)
+			require.NoError(t, err)
+			assert.Equal(t, "uid="+user1+","+tc.userDN, userEntry.DN)
 
-	groupEntry, err := client.GetGroupInfo(groupName)
-	require.NoError(t, err)
-	assert.Equal(t, "cn="+groupName+","+groupDN, groupEntry.DN)
+			groupEntry, err := client.GetGroupInfo(groupName)
+			require.NoError(t, err)
+			assert.Equal(t, "cn="+groupName+","+tc.groupDN, groupEntry.DN)
 
-	rawUserEntry, err := client.Conn.Search(ldap.NewSearchRequest(
-		userDN,
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		"(uid="+user1+")",
-		[]string{"dn"},
-		nil,
-	))
-	require.NoError(t, err)
-	require.Len(t, rawUserEntry.Entries, 1)
+			rawUserEntry, err := client.Conn.Search(ldap.NewSearchRequest(
+				tc.userDN,
+				ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+				"(uid="+user1+")",
+				[]string{"dn"},
+				nil,
+			))
+			require.NoError(t, err)
+			require.Len(t, rawUserEntry.Entries, 1)
 
-	rawGroupEntry, err := client.Conn.Search(ldap.NewSearchRequest(
-		groupDN,
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		"(cn="+groupName+")",
-		[]string{"dn"},
-		nil,
-	))
-	require.NoError(t, err)
-	require.Len(t, rawGroupEntry.Entries, 1)
+			rawGroupEntry, err := client.Conn.Search(ldap.NewSearchRequest(
+				tc.groupDN,
+				ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+				"(cn="+groupName+")",
+				[]string{"dn"},
+				nil,
+			))
+			require.NoError(t, err)
+			require.Len(t, rawGroupEntry.Entries, 1)
+		})
+	}
 }

--- a/internal/ldap/config.go
+++ b/internal/ldap/config.go
@@ -5,6 +5,8 @@ type Config struct {
 	LDAPHost    string `yaml:"ldap_host"`
 	LDAPPort    string `yaml:"ldap_port"`
 	LDAPBaseDN  string `yaml:"ldap_base_dn"`
+	LDAPUserDN  string `yaml:"ldap_user_dn"`
+	LDAPGroupDN string `yaml:"ldap_group_dn"`
 	LDAPBindDN  string `yaml:"ldap_bind_dn"`
 	LDAPBindPwd string `yaml:"ldap_bind_pwd"`
 }

--- a/internal/ldap/group.go
+++ b/internal/ldap/group.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *Client) CreateGroup(groupName string, gidNumber string, memberUids []string) error {
-	base := "ou=Groups," + c.Config.LDAPBaseDN
+	base := c.groupBaseDN()
 
 	filter := fmt.Sprintf("(gidNumber=%s)", ldap.EscapeFilter(gidNumber))
 	exist, err := c.entryExists(base, filter)
@@ -33,7 +33,7 @@ func (c *Client) CreateGroup(groupName string, gidNumber string, memberUids []st
 		return fmt.Errorf("%w: %s", ErrGroupNameExists, groupName)
 	}
 
-	dn := fmt.Sprintf("cn=%s,ou=Groups,%s", groupName, c.Config.LDAPBaseDN)
+	dn := fmt.Sprintf("cn=%s,%s", groupName, c.groupBaseDN())
 	addRequest := ldap.NewAddRequest(dn, nil)
 	addRequest.Attribute("objectClass", []string{"top", "posixGroup"})
 	addRequest.Attribute("cn", []string{groupName})
@@ -67,7 +67,7 @@ func (c *Client) GetGroupInfo(groupName string) (*ldap.Entry, error) {
 	filter := fmt.Sprintf("(cn=%s)", ldap.EscapeFilter(groupName))
 	attributes := []string{"dn", "cn", "memberUid"}
 
-	result, err := c.SearchByFilter("ou=Groups,"+c.Config.LDAPBaseDN, filter, attributes)
+	result, err := c.SearchByFilter(c.groupBaseDN(), filter, attributes)
 	if err != nil {
 		c.Logger.Error("failed to search group", zap.String("groupName", groupName), zap.Error(err))
 		return nil, fmt.Errorf("failed to search group: %w", err)
@@ -82,7 +82,7 @@ func (c *Client) GetGroupInfo(groupName string) (*ldap.Entry, error) {
 }
 
 func (c *Client) DeleteGroup(groupName string) error {
-	dn := fmt.Sprintf("cn=%s,ou=Groups,%s", groupName, c.Config.LDAPBaseDN)
+	dn := fmt.Sprintf("cn=%s,%s", groupName, c.groupBaseDN())
 	deleteRequest := ldap.NewDelRequest(dn, nil)
 	err := c.Conn.Del(deleteRequest)
 	if err != nil {
@@ -110,7 +110,7 @@ func (c *Client) AddUserToGroup(groupName string, memberUid string) error {
 		return fmt.Errorf("%w: %s", ErrUserAlreadyInGroup, memberUid)
 	}
 
-	dn := fmt.Sprintf("cn=%s,ou=Groups,%s", groupName, c.Config.LDAPBaseDN)
+	dn := fmt.Sprintf("cn=%s,%s", groupName, c.groupBaseDN())
 	modifyRequest := ldap.NewModifyRequest(dn, nil)
 	modifyRequest.Add("memberUid", []string{memberUid})
 
@@ -135,7 +135,7 @@ func (c *Client) RemoveUserFromGroup(groupName string, memberUid string) error {
 		return fmt.Errorf("%w: %s", ErrUserNotInGroup, memberUid)
 	}
 
-	dn := fmt.Sprintf("cn=%s,ou=Groups,%s", groupName, c.Config.LDAPBaseDN)
+	dn := fmt.Sprintf("cn=%s,%s", groupName, c.groupBaseDN())
 	modifyRequest := ldap.NewModifyRequest(dn, nil)
 	modifyRequest.Delete("memberUid", []string{memberUid})
 
@@ -150,7 +150,7 @@ func (c *Client) RemoveUserFromGroup(groupName string, memberUid string) error {
 }
 
 func (c *Client) GetGroupsForUser(uid string) ([]*ldap.Entry, error) {
-	userBase := "ou=People," + c.Config.LDAPBaseDN
+	userBase := c.userBaseDN()
 	userFilter := fmt.Sprintf("(uid=%s)", ldap.EscapeFilter(uid))
 	exists, err := c.entryExists(userBase, userFilter)
 	if err != nil {
@@ -160,7 +160,7 @@ func (c *Client) GetGroupsForUser(uid string) ([]*ldap.Entry, error) {
 		return nil, fmt.Errorf("%w: %s", ErrUserNotFound, uid)
 	}
 
-	groupBase := "ou=Groups," + c.Config.LDAPBaseDN
+	groupBase := c.groupBaseDN()
 	groupFilter := fmt.Sprintf("(memberUid=%s)", ldap.EscapeFilter(uid))
 	groupAttributes := []string{"dn", "cn"}
 	result, err := c.SearchByFilter(groupBase, groupFilter, groupAttributes)
@@ -179,7 +179,7 @@ func (c *Client) GetGroupsForUser(uid string) ([]*ldap.Entry, error) {
 }
 
 func (c *Client) GetAllGIDNumbers() ([]string, error) {
-	base := "ou=Groups," + c.Config.LDAPBaseDN
+	base := c.groupBaseDN()
 	filter := "(gidNumber=*)"
 	attributes := []string{"gidNumber"}
 

--- a/internal/ldap/test_util.go
+++ b/internal/ldap/test_util.go
@@ -19,6 +19,11 @@ import (
 
 func newTestClient(t *testing.T) (*Client, func()) {
 	t.Helper()
+	return newTestClientWithDNs(t, "", "")
+}
+
+func newTestClientWithDNs(t *testing.T, userDN, groupDN string) (*Client, func()) {
+	t.Helper()
 
 	logger, _ := zap.NewDevelopment()
 
@@ -66,6 +71,8 @@ func newTestClient(t *testing.T) (*Client, func()) {
 		LDAPHost:    "localhost",
 		LDAPPort:    port,
 		LDAPBaseDN:  "dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club",
+		LDAPUserDN:  userDN,
+		LDAPGroupDN: groupDN,
 		LDAPBindDN:  "cn=admin,dc=clustron,dc=prj,dc=internal,dc=sdc,dc=nycu,dc=club",
 		LDAPBindPwd: "admin",
 	}
@@ -73,7 +80,7 @@ func newTestClient(t *testing.T) (*Client, func()) {
 	client, err := NewClient(cfg, logger)
 	require.NoError(t, err)
 
-	require.NoError(t, setupBaseDIT(client.Conn, cfg.LDAPBaseDN))
+	require.NoError(t, setupBaseDIT(client.Conn, client.userBaseDN(), client.groupBaseDN()))
 
 	return client, cleanup
 }
@@ -111,13 +118,11 @@ func waitForLDAPReady(pool *dockertest.Pool, resource *dockertest.Resource, time
 	})
 }
 
-func setupBaseDIT(c *ldap.Conn, baseDN string) error {
-	orgUnits := []string{"People", "Groups"}
-
-	for _, ou := range orgUnits {
-		req := ldap.NewAddRequest(fmt.Sprintf("ou=%s,%s", ou, baseDN), nil)
+func setupBaseDIT(c *ldap.Conn, dns ...string) error {
+	for _, dn := range dns {
+		req := ldap.NewAddRequest(dn, nil)
 		req.Attribute("objectClass", []string{"organizationalUnit"})
-		req.Attribute("ou", []string{ou})
+		req.Attribute("ou", []string{extractRDNValue(dn, "ou")})
 
 		err := c.Add(req)
 		if err != nil {
@@ -125,10 +130,27 @@ func setupBaseDIT(c *ldap.Conn, baseDN string) error {
 			if errors.As(err, &ldapErr) && ldapErr.ResultCode == ldap.LDAPResultEntryAlreadyExists {
 				continue
 			}
-			return fmt.Errorf("failed to create ou=%s: %w", ou, err)
+			return fmt.Errorf("failed to create dn=%s: %w", dn, err)
 		}
 	}
 	return nil
+}
+
+func extractRDNValue(dn, key string) string {
+	parts := strings.SplitN(dn, ",", 2)
+	if len(parts) == 0 {
+		return ""
+	}
+
+	rdnParts := strings.SplitN(parts[0], "=", 2)
+	if len(rdnParts) != 2 {
+		return ""
+	}
+	if !strings.EqualFold(strings.TrimSpace(rdnParts[0]), key) {
+		return ""
+	}
+
+	return strings.TrimSpace(rdnParts[1])
 }
 
 func setupUser(t *testing.T, c *Client, uid, cn, sn, key, uidNumber string) {

--- a/internal/ldap/user.go
+++ b/internal/ldap/user.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *Client) CreateUser(uid string, cn string, sn string, sshPublicKey string, uidNumber string) error {
-	base := "ou=People," + c.Config.LDAPBaseDN
+	base := c.userBaseDN()
 
 	// check if uid is in use
 	filter := fmt.Sprintf("(uid=%s)", ldap.EscapeFilter(uid))
@@ -77,7 +77,7 @@ func (c *Client) CreateUser(uid string, cn string, sn string, sshPublicKey strin
 }
 
 func (c *Client) GetAllUserByUIDList(uids []string) ([]*ldap.Entry, error) {
-	base := "ou=People," + c.Config.LDAPBaseDN
+	base := c.userBaseDN()
 	filter := "(|"
 	for _, uid := range uids {
 		filter += fmt.Sprintf("(uid=%s)", ldap.EscapeFilter(uid))
@@ -97,7 +97,7 @@ func (c *Client) GetAllUserByUIDList(uids []string) ([]*ldap.Entry, error) {
 }
 
 func (c *Client) GetUserInfo(uid string) (*ldap.Entry, error) {
-	base := "ou=People," + c.Config.LDAPBaseDN
+	base := c.userBaseDN()
 	filter := fmt.Sprintf("(uid=%s)", ldap.EscapeFilter(uid))
 	attributes := []string{
 		"dn", "uid", "cn", "sn", "sshPublicKey", "homeDirectory", "loginShell",
@@ -117,7 +117,7 @@ func (c *Client) GetUserInfo(uid string) (*ldap.Entry, error) {
 }
 
 func (c *Client) GetUserInfoByUIDNumber(uidNumber int64) (*ldap.Entry, error) {
-	base := "ou=People," + c.Config.LDAPBaseDN
+	base := c.userBaseDN()
 	filter := fmt.Sprintf("(uidNumber=%s)", ldap.EscapeFilter(fmt.Sprint(uidNumber)))
 	attributes := []string{
 		"dn", "uid", "cn", "sn", "sshPublicKey", "homeDirectory", "loginShell",
@@ -137,7 +137,7 @@ func (c *Client) GetUserInfoByUIDNumber(uidNumber int64) (*ldap.Entry, error) {
 }
 
 func (c *Client) ExistUser(uid string) (bool, error) {
-	base := "ou=People," + c.Config.LDAPBaseDN
+	base := c.userBaseDN()
 	filter := fmt.Sprintf("(uid=%s)", ldap.EscapeFilter(uid))
 
 	exist, err := c.entryExists(base, filter)
@@ -149,7 +149,7 @@ func (c *Client) ExistUser(uid string) (bool, error) {
 }
 
 func (c *Client) UpdateUser(uid string, cn string, sn string) error {
-	dn := fmt.Sprintf("uid=%s,ou=People,%s", uid, c.Config.LDAPBaseDN)
+	dn := fmt.Sprintf("uid=%s,%s", uid, c.userBaseDN())
 	modifyRequest := ldap.NewModifyRequest(dn, nil)
 	modifyRequest.Replace("cn", []string{cn})
 	modifyRequest.Replace("sn", []string{sn})
@@ -170,7 +170,7 @@ func (c *Client) UpdateUser(uid string, cn string, sn string) error {
 }
 
 func (c *Client) DeleteUser(uid string) error {
-	dn := fmt.Sprintf("uid=%s,ou=People,%s", uid, c.Config.LDAPBaseDN)
+	dn := fmt.Sprintf("uid=%s,%s", uid, c.userBaseDN())
 	deleteRequest := ldap.NewDelRequest(dn, nil)
 
 	err := c.Conn.Del(deleteRequest)
@@ -211,7 +211,7 @@ func (c *Client) GetUsedUIDNumbers() ([]string, error) {
 }
 
 func (c *Client) ExistSSHPublicKey(publicKey string) (bool, error) {
-	base := "ou=People," + c.Config.LDAPBaseDN
+	base := c.userBaseDN()
 	filter := fmt.Sprintf("(sshPublicKey=%s)", ldap.EscapeFilter(publicKey))
 
 	exist, err := c.entryExists(base, filter)
@@ -223,7 +223,7 @@ func (c *Client) ExistSSHPublicKey(publicKey string) (bool, error) {
 }
 
 func (c *Client) AddSSHPublicKey(uid string, publicKey string) error {
-	dn := fmt.Sprintf("uid=%s,ou=People,%s", uid, c.Config.LDAPBaseDN)
+	dn := fmt.Sprintf("uid=%s,%s", uid, c.userBaseDN())
 
 	modifyRequest := ldap.NewModifyRequest(dn, nil)
 	modifyRequest.Add("sshPublicKey", []string{publicKey})
@@ -248,7 +248,7 @@ func (c *Client) AddSSHPublicKey(uid string, publicKey string) error {
 }
 
 func (c *Client) DeleteSSHPublicKey(uid string, publicKey string) error {
-	dn := fmt.Sprintf("uid=%s,ou=People,%s", uid, c.Config.LDAPBaseDN)
+	dn := fmt.Sprintf("uid=%s,%s", uid, c.userBaseDN())
 
 	modifyRequest := ldap.NewModifyRequest(dn, nil)
 	modifyRequest.Delete("sshPublicKey", []string{publicKey})
@@ -296,7 +296,7 @@ func (c *Client) GetAllUIDNumbers() ([]string, error) {
 }
 
 func (c *Client) UpdateUserPassword(uid string, password string) error {
-	dn := fmt.Sprintf("uid=%s,ou=People,%s", uid, c.Config.LDAPBaseDN)
+	dn := fmt.Sprintf("uid=%s,%s", uid, c.userBaseDN())
 	modifyRequest := ldap.NewModifyRequest(dn, nil)
 	modifyRequest.Replace("userPassword", []string{password})
 

--- a/internal/ldap/util.go
+++ b/internal/ldap/util.go
@@ -42,7 +42,7 @@ func (c *Client) entryExists(baseDN, filter string) (bool, error) {
 }
 
 func (c *Client) userInGroup(groupName, uid string) (bool, error) {
-	baseDN := fmt.Sprintf("cn=%s,ou=Groups,%s", groupName, c.Config.LDAPBaseDN)
+	baseDN := fmt.Sprintf("cn=%s,%s", groupName, c.groupBaseDN())
 	filter := fmt.Sprintf("(memberUid=%s)", ldap.EscapeFilter(uid))
 
 	result, err := c.SearchByFilter(baseDN, filter, []string{"dn"})


### PR DESCRIPTION
## What changed
- made LDAP user and group paths configurable through `ldap_user_dn` and `ldap_group_dn`
- updated all LDAP user and group operations to use the configured DNs instead of hard-coded `ou=People` and `ou=Groups`
- changed LDAP validation to verify that the configured user and group DNs exist
- added integration test coverage for configured LDAP DNs and updated test LDAP DIT setup helpers
- documented the new LDAP config fields in `config.example.yaml`

## Why it changed
The backend previously assumed LDAP users always lived under `ou=People` and groups always lived under `ou=Groups` beneath the base DN. This made the service incompatible with LDAP layouts that use different organizational units.

## Impact
- deployments can now point Clustron at custom LDAP user and group containers without code changes
- existing deployments keep working because the client still falls back to `ou=People` and `ou=Groups` when the new config values are not provided
- startup validation now fails against the actual configured LDAP paths instead of the old hard-coded ones

## Validation
- `GOCACHE=/tmp/go-build go test ./internal/ldap/...`
- `GOCACHE=/tmp/go-build go test ./internal/config/...`