### PR TITLE
specify shell for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 GREEN = \033[0;32m
 BLUE = \033[0;34m
 RED = \033[0;31m


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Since the system default shell for ubuntu is dash, its `echo` command won't accept argument `-e` and will treat it like normal string. It's better to unify the environment for a better cross-platform compatibility.

## Additional Information

<img width="466" height="45" alt="image" src="https://github.com/user-attachments/assets/77b7fd68-0106-4155-89d0-076100dffb34" />