### PR TITLE
[CLUST-321] support group member and pending member search

### DIFF
--- a/internal/ldap/client.go
+++ b/internal/ldap/client.go
@@ -7,24 +7,6 @@ import (
 	"go.uber.org/zap"
 )
 
-//mockery:generate: true
-type LDAPClient interface {
-	CreateGroup(groupName, gidNumber string, memberUids []string) error
-	DeleteGroup(groupName string) error
-	AddUserToGroup(groupName, memberUid string) error
-	CreateUser(uid, cn, sn, sshPublicKey, uidNumber string) error
-	DeleteUser(uid string) error
-	AddSSHPublicKey(uid, publicKey string) error
-	DeleteSSHPublicKey(uid string, publicKey string) error
-	GetUserInfo(uid string) (*ldap.Entry, error)
-	GetGroupInfo(groupName string) (*ldap.Entry, error)
-	GetAllUserByUIDList(uidList []string) ([]*ldap.Entry, error)
-	SearchUserByUIDList(uidList []string, query string) ([]*ldap.Entry, error)
-	RemoveUserFromGroup(groupName, memberUid string) error
-	ExistSSHPublicKey(publicKey string) (bool, error)
-	GetAllUIDNumbers() ([]string, error)
-}
-
 type Client struct {
 	Conn   *ldap.Conn
 	Config *Config

--- a/internal/ldap/client.go
+++ b/internal/ldap/client.go
@@ -18,6 +18,8 @@ type LDAPClient interface {
 	DeleteSSHPublicKey(uid string, publicKey string) error
 	GetUserInfo(uid string) (*ldap.Entry, error)
 	GetGroupInfo(groupName string) (*ldap.Entry, error)
+	GetAllUserByUIDList(uidList []string) ([]*ldap.Entry, error)
+	SearchUserByUIDList(uidList []string, query string) ([]*ldap.Entry, error)
 	RemoveUserFromGroup(groupName, memberUid string) error
 	ExistSSHPublicKey(publicKey string) (bool, error)
 	GetAllUIDNumbers() ([]string, error)

--- a/internal/ldap/user.go
+++ b/internal/ldap/user.go
@@ -101,6 +101,44 @@ func (c *Client) GetAllUserByUIDList(uids []string) ([]*ldap.Entry, error) {
 	return result.Entries, nil
 }
 
+func (c *Client) SearchUserByUIDList(uids []string, query string) ([]*ldap.Entry, error) {
+	if len(uids) == 0 {
+		return []*ldap.Entry{}, nil
+	}
+
+	base := "ou=People," + c.Config.LDAPBaseDN
+	var filter strings.Builder
+	filter.WriteString("(&(|")
+	for _, uid := range uids {
+		_, err := fmt.Fprintf(&filter, "(uid=%s)", ldap.EscapeFilter(uid))
+		if err != nil {
+			return nil, err
+		}
+	}
+	filter.WriteString(")")
+
+	if query != "" {
+		escapedQuery := ldap.EscapeFilter(query)
+		_, err := fmt.Fprintf(&filter, "(|(uid=*%s*)(cn=*%s*))", escapedQuery, escapedQuery)
+		if err != nil {
+			return nil, err
+		}
+	}
+	filter.WriteString(")")
+
+	attributes := []string{
+		"dn", "uid", "cn", "sn", "sshPublicKey", "homeDirectory", "loginShell", "uidNumber",
+	}
+
+	result, err := c.SearchByFilter(base, filter.String(), attributes)
+	if err != nil {
+		c.Logger.Error("failed to search users by query", zap.Error(err), zap.String("query", query))
+		return nil, fmt.Errorf("failed to search users: %w", err)
+	}
+
+	return result.Entries, nil
+}
+
 func (c *Client) GetUserInfo(uid string) (*ldap.Entry, error) {
 	base := "ou=People," + c.Config.LDAPBaseDN
 	filter := fmt.Sprintf("(uid=%s)", ldap.EscapeFilter(uid))

--- a/internal/membership/handler.go
+++ b/internal/membership/handler.go
@@ -22,7 +22,7 @@ type Store interface {
 	Remove(ctx context.Context, groupID uuid.UUID, userID uuid.UUID) error
 	Update(ctx context.Context, groupID uuid.UUID, userID uuid.UUID, role uuid.UUID) (MemberResponse, error)
 	CountByGroupID(ctx context.Context, groupID uuid.UUID) (int64, error)
-	ListWithPaged(ctx context.Context, userID uuid.UUID, groupID uuid.UUID, page int, size int, sort string, sortBy string, search string) ([]MemberResponse, int, error)
+	ListWithPaged(ctx context.Context, userID uuid.UUID, groupID uuid.UUID, globalRole string, page int, size int, sort string, sortBy string, search string) ([]MemberResponse, int, error)
 	ListPendingWithPaged(ctx context.Context, groupID uuid.UUID, page int, size int, sort string, sortBy string, search string) ([]PendingMemberResponse, int, error)
 	UpdatePending(ctx context.Context, groupID uuid.UUID, pendingID uuid.UUID, role uuid.UUID) (PendingMemberResponse, error)
 	RemovePending(ctx context.Context, groupID uuid.UUID, pendingID uuid.UUID) error

--- a/internal/membership/handler.go
+++ b/internal/membership/handler.go
@@ -22,8 +22,8 @@ type Store interface {
 	Remove(ctx context.Context, groupID uuid.UUID, userID uuid.UUID) error
 	Update(ctx context.Context, groupID uuid.UUID, userID uuid.UUID, role uuid.UUID) (MemberResponse, error)
 	CountByGroupID(ctx context.Context, groupID uuid.UUID) (int64, error)
-	ListWithPaged(ctx context.Context, groupID uuid.UUID, page int, size int, sort string, sortBy string) ([]MemberResponse, error)
-	ListPendingWithPaged(ctx context.Context, groupID uuid.UUID, page int, size int, sort string, sortBy string) ([]PendingMemberResponse, error)
+	ListWithPaged(ctx context.Context, groupID uuid.UUID, page int, size int, sort string, sortBy string, search string) ([]MemberResponse, int, error)
+	ListPendingWithPaged(ctx context.Context, groupID uuid.UUID, page int, size int, sort string, sortBy string, search string) ([]PendingMemberResponse, int, error)
 	UpdatePending(ctx context.Context, groupID uuid.UUID, pendingID uuid.UUID, role uuid.UUID) (PendingMemberResponse, error)
 	RemovePending(ctx context.Context, groupID uuid.UUID, pendingID uuid.UUID) error
 	CountPendingByGroupID(ctx context.Context, groupID uuid.UUID) (int64, error)
@@ -216,26 +216,23 @@ func (h *Handler) ListGroupMembersPagedHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	members, err := h.store.ListWithPaged(
+	search := r.URL.Query().Get("search")
+
+	members, totalCount, err := h.store.ListWithPaged(
 		traceCtx,
 		groupUUID,
 		pageRequest.Page,
 		pageRequest.Size,
 		pageRequest.Sort,
 		pageRequest.SortBy,
+		search,
 	)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
 		return
 	}
 
-	totalCount, err := h.store.CountByGroupID(traceCtx, groupUUID)
-	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, err, logger)
-		return
-	}
-
-	pageResponse := h.paginationFactory.NewResponse(members, int(totalCount), pageRequest.Page, pageRequest.Size)
+	pageResponse := h.paginationFactory.NewResponse(members, totalCount, pageRequest.Page, pageRequest.Size)
 	handlerutil.WriteJSONResponse(w, http.StatusOK, pageResponse)
 }
 
@@ -257,26 +254,23 @@ func (h *Handler) ListPendingMembersPagedHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	pendingMembers, err := h.store.ListPendingWithPaged(
+	search := r.URL.Query().Get("search")
+
+	pendingMembers, totalCount, err := h.store.ListPendingWithPaged(
 		traceCtx,
 		groupUUID,
 		pageRequest.Page,
 		pageRequest.Size,
 		pageRequest.Sort,
 		pageRequest.SortBy,
+		search,
 	)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
 		return
 	}
 
-	totalCount, err := h.store.CountPendingByGroupID(traceCtx, groupUUID)
-	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, err, logger)
-		return
-	}
-
-	pageResponse := h.pendingPaginationFactory.NewResponse(pendingMembers, int(totalCount), pageRequest.Page, pageRequest.Size)
+	pageResponse := h.pendingPaginationFactory.NewResponse(pendingMembers, totalCount, pageRequest.Page, pageRequest.Size)
 	handlerutil.WriteJSONResponse(w, http.StatusOK, pageResponse)
 }
 

--- a/internal/membership/handler.go
+++ b/internal/membership/handler.go
@@ -74,7 +74,7 @@ func NewHandler(
 		tracer:                   otel.Tracer("member/handler"),
 		store:                    store,
 		userService:              userService,
-		paginationFactory:        pagination.NewFactory[MemberResponse](200, []string{"id"}),
+		paginationFactory:        pagination.NewFactory[MemberResponse](200, []string{"id", "fullName", "studentId"}),
 		pendingPaginationFactory: pagination.NewFactory[PendingMemberResponse](200, []string{"id"}),
 	}
 }

--- a/internal/membership/handler_test.go
+++ b/internal/membership/handler_test.go
@@ -273,8 +273,8 @@ func TestHandler_ListGroupMembersPagedHandler(t *testing.T) {
 	}{
 		{
 			name: "Valid request lists group members",
-			setupMock: func(store *mocks.Store, groupID uuid.UUID) {
-				store.On("ListWithPaged", mock.Anything, user.ID, groupID, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]membership.MemberResponse{
+			setupMock: func(store *mocks.Store, user *jwt.User, groupID uuid.UUID) {
+				store.On("ListWithPaged", mock.Anything, user.ID, groupID, user.Role, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]membership.MemberResponse{
 					{
 						ID: uuid.New(),
 					},
@@ -294,7 +294,7 @@ func TestHandler_ListGroupMembersPagedHandler(t *testing.T) {
 		{
 			name: "Does not exists member returns forbidden",
 			setupMock: func(store *mocks.Store, user *jwt.User, groupID uuid.UUID) {
-				store.On("ListWithPaged", mock.Anything, user.ID, groupID, user.Role, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, handlerutil.ErrForbidden)
+				store.On("ListWithPaged", mock.Anything, user.ID, groupID, user.Role, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, 0, handlerutil.ErrForbidden)
 			},
 			resourceID:     uuid.New().String(),
 			user:           &jwt.User{ID: uuid.New(), Role: role.User.String()},

--- a/internal/membership/handler_test.go
+++ b/internal/membership/handler_test.go
@@ -273,12 +273,11 @@ func TestHandler_ListGroupMembersPagedHandler(t *testing.T) {
 		{
 			name: "Valid request lists group members",
 			setupMock: func(store *mocks.Store, groupID uuid.UUID) {
-				store.On("ListWithPaged", mock.Anything, groupID, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]membership.MemberResponse{
+				store.On("ListWithPaged", mock.Anything, groupID, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]membership.MemberResponse{
 					{
 						ID: uuid.New(),
 					},
-				}, nil).Once()
-				store.On("CountByGroupID", mock.Anything, groupID).Return(int64(1), nil).Once()
+				}, 1, nil).Once()
 			},
 			resourceID:     uuid.New().String(),
 			user:           &jwt.User{ID: uuid.New(), Role: role.Admin.String()},
@@ -337,12 +336,11 @@ func TestHandler_ListPendingMembersPagedHandler(t *testing.T) {
 		{
 			name: "Valid request lists pending group members",
 			setupMock: func(store *mocks.Store, groupID uuid.UUID) {
-				store.On("ListPendingWithPaged", mock.Anything, groupID, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]membership.PendingMemberResponse{
+				store.On("ListPendingWithPaged", mock.Anything, groupID, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]membership.PendingMemberResponse{
 					{
 						ID: uuid.New(),
 					},
-				}, nil).Once()
-				store.On("CountPendingByGroupID", mock.Anything, groupID).Return(int64(1), nil).Once()
+				}, 1, nil).Once()
 			},
 			resourceID:     uuid.New().String(),
 			user:           &jwt.User{ID: uuid.New(), Role: role.Admin.String()},

--- a/internal/membership/queries.sql
+++ b/internal/membership/queries.sql
@@ -62,7 +62,11 @@ FROM memberships AS m
 JOIN group_role AS gr ON gr.id = m.role_id
 JOIN users AS u ON u.id = m.user_id
 LEFT JOIN ldap_user AS l ON l.id = u.id
-WHERE group_id = $1;
+WHERE group_id = $1 AND (
+    u.full_name ILIKE '%' || @search::TEXT || '%' OR
+    u.email ILIKE '%' || @search::TEXT || '%' OR
+    u.student_id ILIKE '%' || @search::TEXT || '%'
+);
 
 -- name: GetByUser :one
 SELECT
@@ -140,7 +144,7 @@ SELECT
     gr.access_level
 FROM pending_memberships AS pm
 JOIN group_role AS gr ON gr.id = pm.role_id
-WHERE pm.group_id = $1
+WHERE pm.group_id = $1 AND (pm.user_identifier ILIKE '%' || @search::TEXT || '%')
 ORDER BY gr.role_name DESC
 LIMIT @Size OFFSET @Skip;
 
@@ -154,9 +158,14 @@ SELECT
     gr.access_level
 FROM pending_memberships AS pm
 JOIN group_role AS gr ON gr.id = pm.role_id
-WHERE pm.group_id = $1
+WHERE pm.group_id = $1 AND (pm.user_identifier ILIKE '%' || @search::TEXT || '%')
 ORDER BY gr.role_name ASC
 LIMIT @Size OFFSET @Skip;
+
+-- name: CountPendingMembersWithSearch :one
+SELECT COUNT(*)
+FROM pending_memberships
+WHERE group_id = $1 AND (user_identifier ILIKE '%' || @search::TEXT || '%');
 
 -- name: CountPendingByGroupID :one
 SELECT COUNT(*) FROM pending_memberships

--- a/internal/membership/service.go
+++ b/internal/membership/service.go
@@ -57,6 +57,7 @@ type LDAPClient interface {
 	RemoveUserFromGroup(groupCN string, username string) error
 	GetGroupInfo(groupCN string) (*ldap.Entry, error)
 	GetAllUserByUIDList(uidList []string) ([]*ldap.Entry, error)
+	SearchUserByUIDList(uidList []string, query string) ([]*ldap.Entry, error)
 }
 
 type Service struct {
@@ -86,58 +87,102 @@ func NewService(logger *zap.Logger, db *pgxpool.Pool, userStore UserStore, group
 	}
 }
 
-func (s *Service) ListWithPaged(ctx context.Context, groupId uuid.UUID, page int, size int, sortDir string, sortBy string) ([]MemberResponse, error) {
+func (s *Service) ListWithPaged(ctx context.Context, groupId uuid.UUID, page int, size int, sortDir string, sortBy string, search string) ([]MemberResponse, int, error) {
 	traceCtx, span := s.tracer.Start(ctx, "ListWithPaged")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
 	// check if the user has access to the group (group owner or group admin)
 	if !s.HasGroupControlAccess(traceCtx, groupId) {
-		return nil, handlerutil.ErrForbidden
+		return nil, 0, handlerutil.ErrForbidden
 	}
 
-	// get base group member list from LDAP
+	membersMap := make(map[int64]MemberResponse)
+
+	// 1. Get all DB members of the group (Search DB first)
+	dbGroupMembers, err := s.queries.GetAll(traceCtx, GetAllParams{
+		GroupID: groupId,
+		Search:  search,
+	})
+	if err != nil {
+		err = databaseutil.WrapDBErrorWithKeyValue(err, "memberships", "group_id", groupId.String(), logger, "get all group members")
+		logger.Error("get all group members failed", zap.Error(err))
+		span.RecordError(err)
+		return nil, 0, err
+	}
+
+	for _, m := range dbGroupMembers {
+		if !m.UidNumber.Valid {
+			continue
+		}
+		membersMap[m.UidNumber.Int64] = MemberResponse{
+			ID:         m.UserID,
+			FullName:   m.FullName.String,
+			Email:      m.Email,
+			StudentID:  m.StudentID.String,
+			OnlyInLDAP: false,
+			UIDNumber:  m.UidNumber.Int64,
+			Role: grouprole.RoleResponse{
+				ID:          m.RoleID.String(),
+				RoleName:    m.RoleName,
+				AccessLevel: m.AccessLevel,
+			},
+		}
+	}
+
+	// 2. Get LDAP members matching the search query (Search LDAP second)
 	ldapBaseGroupCN, err := s.groupStore.GetLDAPBaseGroupCNByGroupID(traceCtx, groupId)
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "ldap_group", "group_id", groupId.String(), logger, "get LDAP base group CN by group ID")
 		logger.Error("get ldap base group cn failed", zap.Error(err))
 		span.RecordError(err)
-		return nil, err
+		return nil, 0, err
 	}
 
-	baseEntries, err := s.getLDAPMember(ldapBaseGroupCN)
+	baseEntries, err := s.getLDAPMember(ldapBaseGroupCN, search)
 	if err != nil {
 		logger.Error("get ldap base group info failed", zap.String("group_cn", ldapBaseGroupCN), zap.Error(err))
 		span.RecordError(err)
-		return nil, err
+		return nil, 0, err
 	}
 
-	// get admin group member list from LDAP
 	ldapAdminGroupCN, err := s.groupStore.GetLDAPAdminGroupCNByGroupID(traceCtx, groupId)
 	if err != nil {
 		err = databaseutil.WrapDBErrorWithKeyValue(err, "ldap_group", "group_id", groupId.String(), logger, "get LDAP admin group CN by group ID")
 		logger.Error("get ldap admin group cn failed", zap.Error(err))
 		span.RecordError(err)
-		return nil, err
+		return nil, 0, err
 	}
 
-	adminEntries, err := s.getLDAPMember(ldapAdminGroupCN)
+	adminEntries, err := s.getLDAPMember(ldapAdminGroupCN, search)
 	if err != nil {
 		logger.Error("get ldap admin group info failed", zap.String("group_cn", ldapAdminGroupCN), zap.Error(err))
 		span.RecordError(err)
-		return nil, err
+		return nil, 0, err
 	}
-
-	ldapEntryMap := make(map[int64]*ldap.Entry)
-	allUIDNumbers := make([]int64, 0)
 
 	processEntries := func(entries []*ldap.Entry) {
 		for _, entry := range entries {
 			var uidNum int64
 			if _, err := fmt.Sscanf(entry.GetAttributeValue("uidNumber"), "%d", &uidNum); err == nil {
-				if _, exists := ldapEntryMap[uidNum]; !exists {
-					ldapEntryMap[uidNum] = entry
-					allUIDNumbers = append(allUIDNumbers, uidNum)
+				// If not in DB membersMap, add as LDAP only
+				if _, exists := membersMap[uidNum]; !exists {
+					membersMap[uidNum] = MemberResponse{
+						UIDNumber:  uidNum,
+						UID:        entry.GetAttributeValue("uid"),
+						FullName:   entry.GetAttributeValue("cn"),
+						OnlyInLDAP: true,
+						Role: grouprole.RoleResponse{
+							ID:          uuid.Nil.String(),
+							RoleName:    grouprole.RoleUnknown.String(),
+							AccessLevel: grouprole.AccessLevelUnknown.String(),
+						},
+					}
+				} else {
+					// Enrich DB record with LDAP UID
+					member := membersMap[uidNum]
+					member.UID = entry.GetAttributeValue("uid")
+					membersMap[uidNum] = member
 				}
 			}
 		}
@@ -146,86 +191,35 @@ func (s *Service) ListWithPaged(ctx context.Context, groupId uuid.UUID, page int
 	processEntries(baseEntries)
 	processEntries(adminEntries)
 
-	dbUserMap, err := s.settingStore.GetAllUserByUIDNumbers(traceCtx, allUIDNumbers)
-	if err != nil {
-		logger.Warn("failed to fetch user IDs from DB, proceeding with LDAP data only", zap.Error(err))
+	allMembers := make([]MemberResponse, 0, len(membersMap))
+	for _, m := range membersMap {
+		allMembers = append(allMembers, m)
 	}
 
-	dbGroupMember, err := s.queries.GetAll(traceCtx, groupId)
-	if err != nil {
-		err = databaseutil.WrapDBErrorWithKeyValue(err, "memberships", "group_id", groupId.String(), logger, "get all group members")
-		logger.Error("get all group members failed", zap.Error(err))
-		span.RecordError(err)
-		return nil, err
-	}
-
-	allMembers := make([]MemberResponse, 0)
-	// Add members that are only in LDAP but not in DB, and also add members that are in both LDAP and DB
-	for uidNum, entry := range ldapEntryMap {
-		res := MemberResponse{
-			UIDNumber: uidNum,
-			UID:       entry.GetAttributeValue("uid"),
-		}
-
-		if userInfo, exist := dbUserMap[uidNum]; exist {
-			res.ID = userInfo.ID
-			res.FullName = userInfo.FullName.String
-			res.Email = userInfo.Email
-			res.StudentID = userInfo.StudentID.String
-			res.OnlyInLDAP = false
-			member, err := s.GetByUser(traceCtx, userInfo.ID, groupId)
-			if err != nil {
-				if errors.Is(err, pgx.ErrNoRows) {
-					res.Role = grouprole.RoleResponse{
-						ID:          uuid.Nil.String(),
-						RoleName:    grouprole.RoleUnknown.String(),
-						AccessLevel: grouprole.AccessLevelUnknown.String(),
-					}
-				}
-			}
-			res.Role = grouprole.RoleResponse{
-				ID:          member.ID.String(),
-				RoleName:    member.RoleName,
-				AccessLevel: member.AccessLevel,
-			}
-		} else {
-			res.OnlyInLDAP = true
-			res.FullName = entry.GetAttributeValue("cn")
-			res.Role = grouprole.RoleResponse{
-				ID:          uuid.Nil.String(),
-				RoleName:    grouprole.RoleUnknown.String(),
-				AccessLevel: grouprole.AccessLevelUnknown.String(),
-			}
-		}
-		allMembers = append(allMembers, res)
-	}
-
-	// Add members that are only in DB but not in LDAP
-	for _, member := range dbGroupMember {
-		if !member.UidNumber.Valid {
-			continue
-		}
-		if _, exist := ldapEntryMap[member.UidNumber.Int64]; !exist {
-			allMembers = append(allMembers, MemberResponse{
-				ID:         member.UserID,
-				FullName:   member.FullName.String,
-				Email:      member.Email,
-				StudentID:  member.StudentID.String,
-				OnlyInLDAP: false,
-				Role: grouprole.RoleResponse{
-					ID:          member.RoleID.String(),
-					RoleName:    member.RoleName,
-					AccessLevel: member.AccessLevel,
-				},
-			})
-		}
-	}
-
+	// 3. Implement Sorting based on sortBy and sortDir
 	sort.Slice(allMembers, func(i, j int) bool {
-		if sortDir == "desc" {
-			return allMembers[i].UIDNumber > allMembers[j].UIDNumber
+		var less bool
+		switch sortBy {
+		case "fullName":
+			less = allMembers[i].FullName < allMembers[j].FullName
+		case "email":
+			less = allMembers[i].Email < allMembers[j].Email
+		case "studentId":
+			less = allMembers[i].StudentID < allMembers[j].StudentID
+		case "uid":
+			less = allMembers[i].UID < allMembers[j].UID
+		case "uidNumber":
+			less = allMembers[i].UIDNumber < allMembers[j].UIDNumber
+		case "id":
+			less = allMembers[i].ID.String() < allMembers[j].ID.String()
+		default:
+			less = allMembers[i].UIDNumber < allMembers[j].UIDNumber
 		}
-		return allMembers[i].UIDNumber < allMembers[j].UIDNumber
+
+		if sortDir == "desc" {
+			return !less
+		}
+		return less
 	})
 
 	totalCount := len(allMembers)
@@ -233,7 +227,7 @@ func (s *Service) ListWithPaged(ctx context.Context, groupId uuid.UUID, page int
 	endIndex := startIndex + size
 
 	if startIndex >= totalCount {
-		return []MemberResponse{}, nil
+		return []MemberResponse{}, totalCount, nil
 	}
 	if endIndex > totalCount {
 		endIndex = totalCount
@@ -241,7 +235,7 @@ func (s *Service) ListWithPaged(ctx context.Context, groupId uuid.UUID, page int
 
 	pagedMembers := allMembers[startIndex:endIndex]
 
-	return pagedMembers, nil
+	return pagedMembers, totalCount, nil
 }
 
 func (s *Service) GetByUser(ctx context.Context, userId uuid.UUID, groupId uuid.UUID) (grouprole.GroupRole, error) {
@@ -1090,7 +1084,7 @@ func (s *Service) isGroupOwner(role grouprole.GroupRole) bool {
 	return role.AccessLevel == string(grouprole.AccessLevelOwner)
 }
 
-func (s *Service) ListPendingWithPaged(ctx context.Context, groupId uuid.UUID, page int, size int, sort string, sortBy string) ([]PendingMemberResponse, error) {
+func (s *Service) ListPendingWithPaged(ctx context.Context, groupId uuid.UUID, page int, size int, sort string, sortBy string, search string) ([]PendingMemberResponse, int, error) {
 	traceCtx, span := s.tracer.Start(ctx, "ListPendingWithPaged")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -1098,22 +1092,22 @@ func (s *Service) ListPendingWithPaged(ctx context.Context, groupId uuid.UUID, p
 	// check if the user has access to the group (group owner or group admin)
 	if !s.HasGroupControlAccess(traceCtx, groupId) {
 		logger.Warn("The user's access is not allowed to control this group")
-		return nil, handlerutil.ErrForbidden
+		return nil, 0, handlerutil.ErrForbidden
 	}
 
 	var pendingMembers []PendingMemberResponse
 	if sort == "desc" {
 		params := ListPendingMembersDescPagedParams{
 			GroupID: groupId,
-			//Sortby:  sortBy,	//TODO: Implement various query with corresponding sortBy
-			Size: int32(size),
-			Skip: int32(page) * int32(size),
+			Size:    int32(size),
+			Skip:    int32(page) * int32(size),
+			Search:  search,
 		}
 		res, err := s.queries.ListPendingMembersDescPaged(traceCtx, params)
 		if err != nil {
 			err = databaseutil.WrapDBError(err, logger, "failed to list pending group members")
 			span.RecordError(err)
-			return nil, err
+			return nil, 0, err
 		}
 		pendingMembers = make([]PendingMemberResponse, len(res))
 		for i, member := range res {
@@ -1131,15 +1125,15 @@ func (s *Service) ListPendingWithPaged(ctx context.Context, groupId uuid.UUID, p
 	} else {
 		params := ListPendingMembersAscPagedParams{
 			GroupID: groupId,
-			//Sortby:  sortBy,	//TODO: Implement various query with corresponding sortBy
-			Size: int32(size),
-			Skip: int32(page) * int32(size),
+			Size:    int32(size),
+			Skip:    int32(page) * int32(size),
+			Search:  search,
 		}
 		res, err := s.queries.ListPendingMembersAscPaged(traceCtx, params)
 		if err != nil {
 			err = databaseutil.WrapDBError(err, logger, "failed to list pending group members")
 			span.RecordError(err)
-			return nil, err
+			return nil, 0, err
 		}
 		pendingMembers = make([]PendingMemberResponse, len(res))
 		for i, member := range res {
@@ -1156,7 +1150,17 @@ func (s *Service) ListPendingWithPaged(ctx context.Context, groupId uuid.UUID, p
 		}
 	}
 
-	return pendingMembers, nil
+	totalCount, err := s.queries.CountPendingMembersWithSearch(traceCtx, CountPendingMembersWithSearchParams{
+		GroupID: groupId,
+		Search:  search,
+	})
+	if err != nil {
+		err = databaseutil.WrapDBError(err, logger, "failed to count pending group members")
+		span.RecordError(err)
+		return nil, 0, err
+	}
+
+	return pendingMembers, int(totalCount), nil
 }
 
 func (s *Service) UpdatePending(ctx context.Context, groupId uuid.UUID, pendingId uuid.UUID, role uuid.UUID) (PendingMemberResponse, error) {
@@ -1341,11 +1345,14 @@ func (s *Service) ProcessPendingMemberships(ctx context.Context, userID uuid.UUI
 	return nil
 }
 
-func (s *Service) getLDAPMember(groupCN string) ([]*ldap.Entry, error) {
+func (s *Service) getLDAPMember(groupCN string, search string) ([]*ldap.Entry, error) {
 	entry, err := s.ldapClient.GetGroupInfo(groupCN)
 	if err != nil || entry == nil {
 		return nil, err
 	}
 	uids := entry.GetAttributeValues("memberUid")
+	if search != "" {
+		return s.ldapClient.SearchUserByUIDList(uids, search)
+	}
 	return s.ldapClient.GetAllUserByUIDList(uids)
 }

--- a/internal/membership/service.go
+++ b/internal/membership/service.go
@@ -202,18 +202,12 @@ func (s *Service) ListWithPaged(ctx context.Context, groupId uuid.UUID, page int
 		switch sortBy {
 		case "fullName":
 			less = allMembers[i].FullName < allMembers[j].FullName
-		case "email":
-			less = allMembers[i].Email < allMembers[j].Email
 		case "studentId":
 			less = allMembers[i].StudentID < allMembers[j].StudentID
-		case "uid":
-			less = allMembers[i].UID < allMembers[j].UID
-		case "uidNumber":
-			less = allMembers[i].UIDNumber < allMembers[j].UIDNumber
 		case "id":
 			less = allMembers[i].ID.String() < allMembers[j].ID.String()
 		default:
-			less = allMembers[i].UIDNumber < allMembers[j].UIDNumber
+			less = allMembers[i].FullName < allMembers[j].FullName
 		}
 
 		if sortDir == "desc" {

--- a/internal/membership/service.go
+++ b/internal/membership/service.go
@@ -87,13 +87,13 @@ func NewService(logger *zap.Logger, db *pgxpool.Pool, userStore UserStore, group
 	}
 }
 
-func (s *Service) ListWithPaged(ctx context.Context, userID, groupID uuid.UUID, page int, size int, sortDir string, sortBy string, search string) ([]MemberResponse, int, error) {
+func (s *Service) ListWithPaged(ctx context.Context, userID, groupID uuid.UUID, globalRole string, page int, size int, sortDir string, sortBy string, search string) ([]MemberResponse, int, error) {
 	traceCtx, span := s.tracer.Start(ctx, "ListWithPaged")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
 	// check if the user has access to the group (group owner or group admin)
-  if globalRole != role.Admin.String() {
+	if globalRole != role.Admin.String() {
 		exists, err := s.Exists(traceCtx, groupID, userID)
 		if err != nil {
 			err = databaseutil.WrapDBErrorWithKeyValue(err, "memberships", "group_id/user_id", fmt.Sprintf("%s/%s", groupID.String(), userID.String()), logger, "check if user has access to the group")


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add group member search functionality
 - Add pending group member search functionality
 - Optimize member retrieval with database-side ILIKE filtering
 - Resolve sortBy being ignored in group member listing

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information
- Removed redundant CountByGroupID and CountPendingByGroupID calls from the handlers, as the total count is now derived during the listing process for better performance.
- Updated unit tests in internal/membership/handler_test.go to align with the new interface signatures.

<!-- Optional: Add any other information that would be helpful for the reviewer. Like detail spec, decisions, trade-offs, links, etc. -->