### PR TITLE
Fix the broken link of 'Developer Guide' in README table of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ We aim to create a service to visualize the LDAP access managing, Slurm operatio
 # Table of Content
 
 - [Deploy](#deploy)
-- [Developer Guide](#get-started)
+- [Developer Guide](#local-development)
 
 # Deploy
 


### PR DESCRIPTION
## Type of changes
- Fix
- Docs

## Purpose
- Fix the link to the local development section in README