### PR TITLE
[CLUST-293] parse response from endpoints /users_association and /accounts_associations

### DIFF
--- a/internal/slurm/service.go
+++ b/internal/slurm/service.go
@@ -1,6 +1,7 @@
 package slurm
 
 import (
+	"bufio"
 	"bytes"
 	"clustron-backend/internal/setting"
 	"context"
@@ -33,19 +34,6 @@ type redisClient interface {
 type settingStore interface {
 	GetLDAPUserInfoByUserID(ctx context.Context, userID uuid.UUID) (setting.LDAPUserInfo, error)
 }
-
-// TODO: parse response from endpoints /users_association and /accounts_association
-//type CreateUserAssociationResponse struct {
-//	AddedUsers     []string
-//	DefaultAccount string
-//	Associations   []Association
-//}
-//
-//type createAccountAssociationResponse struct {
-//	AddedAccounts []string
-//	Description   string
-//	Organization  string
-//}
 
 type Service struct {
 	logger               *zap.Logger
@@ -704,7 +692,7 @@ func (s *Service) CreateAssociation(ctx context.Context, associations []Associat
 	return nil
 }
 
-func (s *Service) CreateUserAssociation(ctx context.Context, userNames, accountNames, clusterNames []string) error {
+func (s *Service) CreateUserAssociation(ctx context.Context, userNames, accountNames, clusterNames []string) (ParsedUserAssociationResponse, error) {
 	traceCtx, span := s.tracer.Start(ctx, "CreateUserAssociation")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -724,14 +712,14 @@ func (s *Service) CreateUserAssociation(ctx context.Context, userNames, accountN
 	if err != nil {
 		logger.Error("failed to marshal user associations request", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedUserAssociationResponse{}, err
 	}
 
 	httpRequest, err := http.NewRequest(http.MethodPost, requestPath, bytes.NewReader(requestBody))
 	if err != nil {
 		logger.Error("failed to create http request", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedUserAssociationResponse{}, err
 	}
 
 	httpRequest.Header.Add("X-SLURM-USER-TOKEN", s.slurmRootToken)
@@ -741,7 +729,7 @@ func (s *Service) CreateUserAssociation(ctx context.Context, userNames, accountN
 	if err != nil {
 		logger.Error("failed to perform http request", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedUserAssociationResponse{}, err
 	}
 	defer func() {
 		if cerr := response.Body.Close(); cerr != nil {
@@ -754,15 +742,15 @@ func (s *Service) CreateUserAssociation(ctx context.Context, userNames, accountN
 		err = fmt.Errorf("unexpected http status code: %d", response.StatusCode)
 		logger.Error("failed to create Slurm user association", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedUserAssociationResponse{}, err
 	}
 
-	var associationsResponse Response
+	var associationsResponse CreateUserAssociationResponse
 	err = ParseResponse(traceCtx, response, &associationsResponse)
 	if err != nil {
 		logger.Error("failed to parse response", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedUserAssociationResponse{}, err
 	}
 
 	// Slurm returns HTTP 200 even for logical failures.
@@ -784,15 +772,17 @@ func (s *Service) CreateUserAssociation(ctx context.Context, userNames, accountN
 			apiErr := fmt.Errorf("slurm API rejected user association creation: %s", strings.Join(errorMsgs, "; "))
 			logger.Error("slurm api returned errors", zap.Error(apiErr))
 			span.RecordError(apiErr)
-			return apiErr
+			return ParsedUserAssociationResponse{}, apiErr
 		}
 	}
 
+	parsedResponse := ParseUserAssociationResponse(associationsResponse.AddedUsers)
+
 	logger.Info("successfully created user associations in slurm")
-	return nil
+	return parsedResponse, nil
 }
 
-func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, clusterNames []string) error {
+func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, clusterNames []string) (ParsedAccountAssociationResponse, error) {
 	traceCtx, span := s.tracer.Start(ctx, "CreateAccountAssociation")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -811,14 +801,14 @@ func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, cl
 	if err != nil {
 		logger.Error("failed to marshal account associations request", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedAccountAssociationResponse{}, err
 	}
 
 	httpRequest, err := http.NewRequest(http.MethodPost, requestPath, bytes.NewReader(requestBody))
 	if err != nil {
 		logger.Error("failed to create http request", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedAccountAssociationResponse{}, err
 	}
 
 	httpRequest.Header.Add("X-SLURM-USER-TOKEN", s.slurmRootToken)
@@ -828,7 +818,7 @@ func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, cl
 	if err != nil {
 		logger.Error("failed to perform http request", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedAccountAssociationResponse{}, err
 	}
 	defer func() {
 		if cerr := response.Body.Close(); cerr != nil {
@@ -841,15 +831,15 @@ func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, cl
 		err = fmt.Errorf("unexpected http status code: %d", response.StatusCode)
 		logger.Error("failed to create Slurm user association", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedAccountAssociationResponse{}, err
 	}
 
-	var associationsResponse Response
+	var associationsResponse CreateAccountAssociationResponse
 	err = ParseResponse(traceCtx, response, &associationsResponse)
 	if err != nil {
 		logger.Error("failed to parse response", zap.Error(err))
 		span.RecordError(err)
-		return err
+		return ParsedAccountAssociationResponse{}, err
 	}
 
 	// Slurm returns HTTP 200 even for logical failures.
@@ -871,12 +861,14 @@ func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, cl
 			apiErr := fmt.Errorf("slurm API rejected account association creation: %s", strings.Join(errorMsgs, "; "))
 			logger.Error("slurm api returned errors", zap.Error(apiErr))
 			span.RecordError(apiErr)
-			return apiErr
+			return ParsedAccountAssociationResponse{}, apiErr
 		}
 	}
 
+	parsedResponse := ParseAccountAssociationResponse(associationsResponse.AddedAccounts)
+
 	logger.Info("successfully created account associations in slurm")
-	return nil
+	return parsedResponse, nil
 }
 
 func (s *Service) DeleteUser(ctx context.Context, userName string) error {
@@ -1118,127 +1110,133 @@ func ParseResponse(ctx context.Context, r *http.Response, s interface{}) error {
 }
 
 // TODO: parse response from endpoints /users_association and /accounts_association
-//func ParseUserAssociationResponse(input string) CreateUserAssociationResponse {
-//	var result CreateUserAssociationResponse
-//
-//	scanner := bufio.NewScanner(strings.NewReader(input))
-//	var section string
-//
-//	for scanner.Scan() {
-//		line := scanner.Text()
-//		trimmed := strings.TrimSpace(line)
-//
-//		if trimmed == "" {
-//			continue
-//		}
-//
-//		// Detect section headers (single leading space, no leading double space)
-//		if strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "  ") {
-//			header := strings.TrimSpace(strings.TrimSuffix(trimmed, "="))
-//			section = strings.ToLower(header)
-//			continue
-//		}
-//
-//		// Parse content lines (double leading space = content under a section)
-//		switch section {
-//			case "adding user(s)":
-//				result.AddedUsers = append(result.AddedUsers, trimmed)
-//
-//			case "settings":
-//				key, value, found := strings.Cut(trimmed, "=")
-//				if !found {
-//					continue
-//				}
-//				key = strings.TrimSpace(key)
-//				value = strings.TrimSpace(value)
-//				if strings.EqualFold(key, "Default Account") {
-//					result.DefaultAccount = value
-//				}
-//
-//			case "associations":
-//			if assoc, ok := ParseAssociation(trimmed); ok {
-//				result.Associations = append(result.Associations, assoc)
-//			}
-//		}
-//	}
-//
-//	return result
-//}
-//
-//func parseAccounts(input string) createAccountAssociationResponse {
-//	var result createAccountAssociationResponse
-//
-//	scanner := bufio.NewScanner(strings.NewReader(input))
-//	var section string
-//
-//	for scanner.Scan() {
-//		line := scanner.Text()
-//		trimmed := strings.TrimSpace(line)
-//
-//		if trimmed == "" {
-//			continue
-//		}
-//
-//		// Root-level line (no leading space): freeform messages
-//		if !strings.HasPrefix(line, " ") {
-//			continue
-//		}
-//
-//		// Section header: exactly 1 leading space
-//		if strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "  ") {
-//			header := strings.TrimSpace(strings.TrimSuffix(trimmed, "="))
-//			section = strings.ToLower(strings.TrimSpace(header))
-//			continue
-//		}
-//
-//		// Content line: 2+ leading spaces
-//		switch section {
-//			case "adding account(s)":
-//				result.AddedAccounts = append(result.AddedAccounts, trimmed)
-//
-//			case "settings":
-//				key, value, found := strings.Cut(trimmed, "=")
-//				if !found {
-//					continue
-//				}
-//				key = strings.TrimSpace(key)
-//				value = strings.TrimSpace(value)
-//				switch strings.ToLower(key) {
-//					case "description":
-//						result.Description = value
-//					case "organization":
-//						result.Organization = value
-//				}
-//
-//
-//		}
-//	}
-//
-//	return result
-//}
-//
-//// parseAssociation parses "C = head       A = base" into an Association.
-//func ParseAssociation(line string) (Association, bool) {
-//	var assoc Association
-//
-//	fields := strings.Fields(line) // ["C", "=", "head", "A", "=", "base"]
-//	for i := 0; i+2 < len(fields); i++ {
-//		if fields[i+1] != "=" {
-//			continue
-//		}
-//		switch strings.ToUpper(fields[i]) {
-//			case "C":
-//				assoc.Cluster = fields[i+2]
-//			case "A":
-//				assoc.Account = fields[i+2]
-//			case "U":
-//				assoc.User = fields[i+2]
-//		}
-//		i += 2
-//	}
-//
-//	if assoc.Cluster == "" && assoc.Account == "" {
-//		return assoc, false
-//	}
-//	return assoc, true
-//}
+func ParseUserAssociationResponse(input string) ParsedUserAssociationResponse {
+	input = strings.ReplaceAll(input, `\n`, "\n")
+
+	var result ParsedUserAssociationResponse
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	var section string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" {
+			continue
+		}
+
+		// Detect section headers (single leading space, no leading double space)
+		if strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "  ") {
+			header := strings.TrimSpace(strings.TrimSuffix(trimmed, "="))
+			section = strings.ToLower(header)
+			continue
+		}
+		// Parse content lines (double leading space = content under a section)
+		switch section {
+		case "adding user(s)":
+			result.AddedUsers = append(result.AddedUsers, trimmed)
+
+		case "settings":
+			key, value, found := strings.Cut(trimmed, "=")
+			if !found {
+				continue
+			}
+			switch strings.TrimSpace(strings.ToLower(key)) {
+			case "default account":
+				result.DefaultAccount = strings.TrimSpace(value)
+			case "admin level":
+				result.AdminLevel = strings.TrimSpace(value)
+			}
+
+		case "associations":
+			if assoc, ok := ParseAssociation(trimmed); ok {
+				result.Associations = append(result.Associations, assoc)
+			}
+		}
+	}
+
+	return result
+}
+
+func ParseAccountAssociationResponse(input string) ParsedAccountAssociationResponse {
+	input = strings.ReplaceAll(input, `\n`, "\n")
+
+	var result ParsedAccountAssociationResponse
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	var section string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		// Root-level line (no leading space): freeform messages
+		if !strings.HasPrefix(line, " ") {
+			continue
+		}
+
+		// Section header: exactly 1 leading space
+		if strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "  ") {
+			header := strings.TrimSpace(strings.TrimSuffix(trimmed, "="))
+			section = strings.ToLower(strings.TrimSpace(header))
+			continue
+		}
+		// Content line: 2+ leading spaces
+		switch section {
+		case "adding account(s)":
+			result.AddedAccounts = append(result.AddedAccounts, trimmed)
+
+		case "settings":
+			key, value, found := strings.Cut(trimmed, "=")
+			if !found {
+				continue
+			}
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			switch strings.ToLower(key) {
+			case "description":
+				result.Description = value
+			case "organization":
+				result.Organization = strings.ReplaceAll(value, `\`, "")
+			}
+		case "associations":
+			if assoc, ok := ParseAssociation(trimmed); ok {
+				result.Associations = append(result.Associations, assoc)
+			}
+		default:
+			continue
+		}
+	}
+
+	return result
+}
+
+// parseAssociation parses "C = head       A = base" into an Association.
+func ParseAssociation(line string) (Association, bool) {
+	var assoc Association
+
+	fields := strings.Fields(line) // ["C", "=", "head", "A", "=", "base"]
+	for i := 0; i+2 < len(fields); i++ {
+		if fields[i+1] != "=" {
+			continue
+		}
+		switch strings.ToUpper(fields[i]) {
+		case "C":
+			assoc.Cluster = fields[i+2]
+		case "A":
+			assoc.Account = fields[i+2]
+		case "U":
+			assoc.User = fields[i+2]
+		}
+		i += 2
+	}
+
+	if assoc.Cluster == "" && assoc.Account == "" {
+		return assoc, false
+	}
+	return assoc, true
+}

--- a/internal/slurm/service.go
+++ b/internal/slurm/service.go
@@ -1109,24 +1109,27 @@ func ParseResponse(ctx context.Context, r *http.Response, s interface{}) error {
 	return nil
 }
 
-// The association endpoints return a sacctmgr-style text body laid out in
-// indented sections: a section header is indented by a single space (e.g.
-// "Adding User(s)", "Settings", "Associations"), and the lines belonging to it
-// are indented by two or more spaces (e.g. "Default Account = base" or
-// "C = head  A = base  U = user1"). These regexes drive the parsing instead of
-// ad-hoc string slicing.
+// The association endpoints return a sacctmgr-style text body whose structure
+// is purely positional: a line indented by exactly one space is a section
+// header ("Adding User(s)", "Settings", "Associations"); a line indented by two
+// or more spaces is content belonging to the current section; a line with no
+// indentation is a freeform message to be ignored. The regexes below own that
+// grammar so the parsing logic never has to slice or prefix-test strings by
+// hand.
 var (
-	// associationSectionHeaderRe matches a section header: exactly one leading
-	// space followed by the header text, with an optional trailing "=". Content
-	// lines are indented further, so the leading "\S" guards against matching
-	// them.
-	associationSectionHeaderRe = regexp.MustCompile(`^ (\S.*?)\s*=?\s*$`)
-	// associationSettingRe matches a "key = value" line, capturing the key and
-	// the value with surrounding whitespace stripped.
-	associationSettingRe = regexp.MustCompile(`^\s*(.+?)\s*=\s*(.*?)\s*$`)
+	// associationLineRe classifies one line. Exactly one of the named "header"
+	// or "content" groups is populated (both already stripped of surrounding
+	// whitespace and any trailing "="); a blank or non-indented freeform line
+	// does not match at all.
+	associationLineRe = regexp.MustCompile(`^(?: (?P<header>\S.*?)| {2,}(?P<content>\S.*?))\s*=?\s*$`)
+	// associationSettingRe splits a "key = value" content line.
+	associationSettingRe = regexp.MustCompile(`^(.+?)\s*=\s*(.*?)\s*$`)
 	// associationFieldRe matches the "C = head", "A = base", "U = user" tokens
-	// of an association line.
+	// of an association content line.
 	associationFieldRe = regexp.MustCompile(`([A-Za-z])\s*=\s*(\S+)`)
+
+	associationHeaderIdx  = associationLineRe.SubexpIndex("header")
+	associationContentIdx = associationLineRe.SubexpIndex("content")
 )
 
 func ParseUserAssociationResponse(input string) ParsedUserAssociationResponse {
@@ -1136,27 +1139,22 @@ func ParseUserAssociationResponse(input string) ParsedUserAssociationResponse {
 	var section string
 
 	for _, line := range strings.Split(input, "\n") {
-		if strings.TrimSpace(line) == "" {
+		m := associationLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue // blank line or root-level freeform message
+		}
+		if header := m[associationHeaderIdx]; header != "" {
+			section = strings.ToLower(header)
 			continue
 		}
-
-		// A single-leading-space line starts a new section.
-		if m := associationSectionHeaderRe.FindStringSubmatch(line); m != nil {
-			section = strings.ToLower(m[1])
-			continue
-		}
-
-		// Skip root-level freeform messages (no leading indentation).
-		if !strings.HasPrefix(line, " ") {
-			continue
-		}
+		content := m[associationContentIdx]
 
 		switch section {
 		case "adding user(s)":
-			result.AddedUsers = append(result.AddedUsers, strings.TrimSpace(line))
+			result.AddedUsers = append(result.AddedUsers, content)
 
 		case "settings":
-			if key, value, ok := parseAssociationSetting(line); ok {
+			if key, value, ok := parseAssociationSetting(content); ok {
 				switch key {
 				case "default account":
 					result.DefaultAccount = value
@@ -1166,7 +1164,7 @@ func ParseUserAssociationResponse(input string) ParsedUserAssociationResponse {
 			}
 
 		case "associations":
-			if assoc, ok := ParseAssociation(line); ok {
+			if assoc, ok := ParseAssociation(content); ok {
 				result.Associations = append(result.Associations, assoc)
 			}
 		}
@@ -1182,26 +1180,22 @@ func ParseAccountAssociationResponse(input string) ParsedAccountAssociationRespo
 	var section string
 
 	for _, line := range strings.Split(input, "\n") {
-		if strings.TrimSpace(line) == "" {
+		m := associationLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue // blank line or root-level freeform message
+		}
+		if header := m[associationHeaderIdx]; header != "" {
+			section = strings.ToLower(header)
 			continue
 		}
-
-		if m := associationSectionHeaderRe.FindStringSubmatch(line); m != nil {
-			section = strings.ToLower(m[1])
-			continue
-		}
-
-		// Skip root-level freeform messages (no leading indentation).
-		if !strings.HasPrefix(line, " ") {
-			continue
-		}
+		content := m[associationContentIdx]
 
 		switch section {
 		case "adding account(s)":
-			result.AddedAccounts = append(result.AddedAccounts, strings.TrimSpace(line))
+			result.AddedAccounts = append(result.AddedAccounts, content)
 
 		case "settings":
-			if key, value, ok := parseAssociationSetting(line); ok {
+			if key, value, ok := parseAssociationSetting(content); ok {
 				switch key {
 				case "description":
 					result.Description = value
@@ -1211,7 +1205,7 @@ func ParseAccountAssociationResponse(input string) ParsedAccountAssociationRespo
 			}
 
 		case "associations":
-			if assoc, ok := ParseAssociation(line); ok {
+			if assoc, ok := ParseAssociation(content); ok {
 				result.Associations = append(result.Associations, assoc)
 			}
 		}

--- a/internal/slurm/service.go
+++ b/internal/slurm/service.go
@@ -1,7 +1,6 @@
 package slurm
 
 import (
-	"bufio"
 	"bytes"
 	"clustron-backend/internal/setting"
 	"context"
@@ -10,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	logutil "github.com/NYCU-SDC/summer/pkg/log"
@@ -1109,48 +1109,64 @@ func ParseResponse(ctx context.Context, r *http.Response, s interface{}) error {
 	return nil
 }
 
-// TODO: parse response from endpoints /users_association and /accounts_association
+// The association endpoints return a sacctmgr-style text body laid out in
+// indented sections: a section header is indented by a single space (e.g.
+// "Adding User(s)", "Settings", "Associations"), and the lines belonging to it
+// are indented by two or more spaces (e.g. "Default Account = base" or
+// "C = head  A = base  U = user1"). These regexes drive the parsing instead of
+// ad-hoc string slicing.
+var (
+	// associationSectionHeaderRe matches a section header: exactly one leading
+	// space followed by the header text, with an optional trailing "=". Content
+	// lines are indented further, so the leading "\S" guards against matching
+	// them.
+	associationSectionHeaderRe = regexp.MustCompile(`^ (\S.*?)\s*=?\s*$`)
+	// associationSettingRe matches a "key = value" line, capturing the key and
+	// the value with surrounding whitespace stripped.
+	associationSettingRe = regexp.MustCompile(`^\s*(.+?)\s*=\s*(.*?)\s*$`)
+	// associationFieldRe matches the "C = head", "A = base", "U = user" tokens
+	// of an association line.
+	associationFieldRe = regexp.MustCompile(`([A-Za-z])\s*=\s*(\S+)`)
+)
+
 func ParseUserAssociationResponse(input string) ParsedUserAssociationResponse {
 	input = strings.ReplaceAll(input, `\n`, "\n")
 
 	var result ParsedUserAssociationResponse
-
-	scanner := bufio.NewScanner(strings.NewReader(input))
 	var section string
 
-	for scanner.Scan() {
-		line := scanner.Text()
-		trimmed := strings.TrimSpace(line)
-
-		if trimmed == "" {
+	for _, line := range strings.Split(input, "\n") {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
 
-		// Detect section headers (single leading space, no leading double space)
-		if strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "  ") {
-			header := strings.TrimSpace(strings.TrimSuffix(trimmed, "="))
-			section = strings.ToLower(header)
+		// A single-leading-space line starts a new section.
+		if m := associationSectionHeaderRe.FindStringSubmatch(line); m != nil {
+			section = strings.ToLower(m[1])
 			continue
 		}
-		// Parse content lines (double leading space = content under a section)
+
+		// Skip root-level freeform messages (no leading indentation).
+		if !strings.HasPrefix(line, " ") {
+			continue
+		}
+
 		switch section {
 		case "adding user(s)":
-			result.AddedUsers = append(result.AddedUsers, trimmed)
+			result.AddedUsers = append(result.AddedUsers, strings.TrimSpace(line))
 
 		case "settings":
-			key, value, found := strings.Cut(trimmed, "=")
-			if !found {
-				continue
-			}
-			switch strings.TrimSpace(strings.ToLower(key)) {
-			case "default account":
-				result.DefaultAccount = strings.TrimSpace(value)
-			case "admin level":
-				result.AdminLevel = strings.TrimSpace(value)
+			if key, value, ok := parseAssociationSetting(line); ok {
+				switch key {
+				case "default account":
+					result.DefaultAccount = value
+				case "admin level":
+					result.AdminLevel = value
+				}
 			}
 
 		case "associations":
-			if assoc, ok := ParseAssociation(trimmed); ok {
+			if assoc, ok := ParseAssociation(line); ok {
 				result.Associations = append(result.Associations, assoc)
 			}
 		}
@@ -1163,76 +1179,71 @@ func ParseAccountAssociationResponse(input string) ParsedAccountAssociationRespo
 	input = strings.ReplaceAll(input, `\n`, "\n")
 
 	var result ParsedAccountAssociationResponse
-
-	scanner := bufio.NewScanner(strings.NewReader(input))
 	var section string
 
-	for scanner.Scan() {
-		line := scanner.Text()
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
+	for _, line := range strings.Split(input, "\n") {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
 
-		// Root-level line (no leading space): freeform messages
+		if m := associationSectionHeaderRe.FindStringSubmatch(line); m != nil {
+			section = strings.ToLower(m[1])
+			continue
+		}
+
+		// Skip root-level freeform messages (no leading indentation).
 		if !strings.HasPrefix(line, " ") {
 			continue
 		}
 
-		// Section header: exactly 1 leading space
-		if strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "  ") {
-			header := strings.TrimSpace(strings.TrimSuffix(trimmed, "="))
-			section = strings.ToLower(strings.TrimSpace(header))
-			continue
-		}
-		// Content line: 2+ leading spaces
 		switch section {
 		case "adding account(s)":
-			result.AddedAccounts = append(result.AddedAccounts, trimmed)
+			result.AddedAccounts = append(result.AddedAccounts, strings.TrimSpace(line))
 
 		case "settings":
-			key, value, found := strings.Cut(trimmed, "=")
-			if !found {
-				continue
+			if key, value, ok := parseAssociationSetting(line); ok {
+				switch key {
+				case "description":
+					result.Description = value
+				case "organization":
+					result.Organization = strings.ReplaceAll(value, `\`, "")
+				}
 			}
-			key = strings.TrimSpace(key)
-			value = strings.TrimSpace(value)
-			switch strings.ToLower(key) {
-			case "description":
-				result.Description = value
-			case "organization":
-				result.Organization = strings.ReplaceAll(value, `\`, "")
-			}
+
 		case "associations":
-			if assoc, ok := ParseAssociation(trimmed); ok {
+			if assoc, ok := ParseAssociation(line); ok {
 				result.Associations = append(result.Associations, assoc)
 			}
-		default:
-			continue
 		}
 	}
 
 	return result
 }
 
-// parseAssociation parses "C = head       A = base" into an Association.
+// parseAssociationSetting extracts a lower-cased key and its value from a
+// "key = value" settings line, reporting whether a "=" was present.
+func parseAssociationSetting(line string) (key, value string, ok bool) {
+	m := associationSettingRe.FindStringSubmatch(line)
+	if m == nil {
+		return "", "", false
+	}
+	return strings.ToLower(m[1]), m[2], true
+}
+
+// ParseAssociation extracts the cluster (C), account (A) and user (U) tokens
+// from an association line such as "C = head       A = base       U = user".
 func ParseAssociation(line string) (Association, bool) {
 	var assoc Association
 
-	fields := strings.Fields(line) // ["C", "=", "head", "A", "=", "base"]
-	for i := 0; i+2 < len(fields); i++ {
-		if fields[i+1] != "=" {
-			continue
-		}
-		switch strings.ToUpper(fields[i]) {
+	for _, m := range associationFieldRe.FindAllStringSubmatch(line, -1) {
+		switch strings.ToUpper(m[1]) {
 		case "C":
-			assoc.Cluster = fields[i+2]
+			assoc.Cluster = m[2]
 		case "A":
-			assoc.Account = fields[i+2]
+			assoc.Account = m[2]
 		case "U":
-			assoc.User = fields[i+2]
+			assoc.User = m[2]
 		}
-		i += 2
 	}
 
 	if assoc.Cluster == "" && assoc.Account == "" {

--- a/internal/slurm/service_test.go
+++ b/internal/slurm/service_test.go
@@ -1,0 +1,95 @@
+package slurm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseUserAssociationResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected ParsedUserAssociationResponse
+	}{
+		{
+			name: "valid user association response with multiple users and associations",
+			input: ` Adding User(s)\n` +
+				`  user1\n` +
+				`  user2\n` +
+				` Settings\n` +
+				`  Default Account = testaccount\n` +
+				`  Admin Level = None\n` +
+				` Associations\n` +
+				`  C = head       A = testaccount                U = user1     \n` +
+				`  C = head       A = testaccount                U = user2     \n`,
+			expected: ParsedUserAssociationResponse{
+				AddedUsers:     []string{"user1", "user2"},
+				DefaultAccount: "testaccount",
+				AdminLevel:     "None",
+				Associations: []Association{
+					{User: "user1", Account: "testaccount", Cluster: "head"},
+					{User: "user2", Account: "testaccount", Cluster: "head"},
+				},
+			},
+		},
+		{
+			name:  "empty or empty lines only",
+			input: "\n\n",
+			expected: ParsedUserAssociationResponse{
+				AddedUsers:   nil,
+				Associations: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseUserAssociationResponse(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestParseAccountAssociationResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected ParsedAccountAssociationResponse
+	}{
+		{
+			name: "valid account association response",
+			input: ` Adding Account(s)\n` +
+				`  acc1\n` +
+				` Settings\n` +
+				`  Description = test account description\n` +
+				`  Organization = testorg\n` +
+				` Associations\n` +
+				`  A = acc1       C = dev-cluster\n`,
+			expected: ParsedAccountAssociationResponse{
+				AddedAccounts: []string{"acc1"},
+				Description:   "test account description",
+				Organization:  "testorg",
+				Associations: []Association{
+					{Account: "acc1", Cluster: "dev-cluster"},
+				},
+			},
+		},
+		{
+			name: "ignore root level lines",
+			input: `freeform message to ignore\n` +
+				` Adding Account(s)\n` +
+				`  acc2\n`,
+			expected: ParsedAccountAssociationResponse{
+				AddedAccounts: []string{"acc2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseAccountAssociationResponse(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/internal/slurm/types.go
+++ b/internal/slurm/types.go
@@ -110,6 +110,32 @@ type Response struct {
 	Warnings []SlurmWarning `json:"warnings"`
 }
 
+type CreateUserAssociationResponse struct {
+	AddedUsers string         `json:"added_users"`
+	Errors     []SlurmError   `json:"errors"`
+	Warnings   []SlurmWarning `json:"warnings"`
+}
+
+type CreateAccountAssociationResponse struct {
+	AddedAccounts string         `json:"added_accounts"`
+	Errors        []SlurmError   `json:"errors"`
+	Warnings      []SlurmWarning `json:"warnings"`
+}
+
+type ParsedUserAssociationResponse struct {
+	AddedUsers     []string
+	DefaultAccount string
+	AdminLevel     string
+	Associations   []Association
+}
+
+type ParsedAccountAssociationResponse struct {
+	AddedAccounts []string
+	Description   string
+	Organization  string
+	Associations  []Association
+}
+
 type DeleteUserResponse struct {
 	RemovedUsers []string       `json:"removed_users"`
 	Errors       []SlurmError   `json:"errors"`


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Parse response from endpoints /users_association and /accounts_associations
- add test case for the parse functions

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information
- Example response field: "added_users": " Adding User(s)\n  howard\n Settings\n  Default Account = base\n  Admin Level     = Administrator\n Associations =\n  C = head       A = admin                U = howard   \n  C = head       A = base                 U = howard   \n",
<!-- Optional: Add any other information that would be helpful for the reviewer. Like detail spec, decisions, trade-offs, links, etc. -->