### PR TITLE
[CLUST-328] unify user role response of List Groups and Get Group.

### DIFF
--- a/internal/grouprole/service.go
+++ b/internal/grouprole/service.go
@@ -282,20 +282,19 @@ func (s *Service) GetTypeByUser(ctx context.Context, userRole string, userID uui
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	roleType := "membership"
-	if userRole == role.Admin.String() {
-		roleType = "adminOverride"
-		return GroupRole{}, roleType, nil
-	}
-
 	groupRole, err := s.GetByUser(traceCtx, userID, groupID)
 	if err != nil {
+		// A system admin who isn't a member of the group falls back to admin override.
+		// Group membership takes precedence, so this is only reached when no membership exists.
 		if errors.As(err, &handlerutil.NotFoundError{}) {
+			if userRole == role.Admin.String() {
+				return GroupRole{}, "adminOverride", nil
+			}
 			err = databaseutil.WrapDBErrorWithKeyValue(err, "group_role", fmt.Sprintf("(%s, %s)", "group_id", "user_id"), fmt.Sprintf("(%s, %s)", groupID.String(), userID.String()), logger, "get group role by user id and group id")
 		}
 		span.RecordError(err)
 		return GroupRole{}, "", err
 	}
 
-	return groupRole, roleType, nil
+	return groupRole, "membership", nil
 }


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- `GetTypeByUser` now looks up the group membership first and only returns `adminOverride` when the membership lookup returns NotFound *and* the user is a system admin.

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information

<!-- Optional: Add any other information that would be helpful for the reviewer. Like detail spec, decisions, trade-offs, links, etc. -->