### PR TITLE
Document custom people and group OU setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,16 @@ We recommend to configure with environment variables.
 
 ### LDAP
 
-| Variable      | Description                                        | Required |
-| ------------- | -------------------------------------------------- | -------- |
-| LDAP_DEBUG    | Enable LDAP debug logging (`true` / `false`)       | No       |
-| LDAP_HOST     | Hostname of the LDAP server                        | Yes      |
-| LDAP_PORT     | Port of the LDAP server (default: `389`)           | Yes      |
-| LDAP_BASE_DN  | Base Distinguished Name for LDAP queries           | Yes      |
-| LDAP_BIND_DN  | Distinguished Name used to bind to the LDAP server | Yes      |
-| LDAP_BIND_PWD | Password for the LDAP bind DN                      | Yes      |
+| Variable           | Description                                                                                            | Required |
+|--------------------|--------------------------------------------------------------------------------------------------------| -------- |
+| LDAP_DEBUG         | Enable LDAP debug logging (`true` / `false`)                                                           | No       |
+| LDAP_HOST          | Hostname of the LDAP server                                                                            | Yes      |
+| LDAP_PORT          | Port of the LDAP server (default: `389`)                                                               | Yes      |
+| LDAP_BASE_DN       | Base Distinguished Name for LDAP queries                                                               | Yes      |
+| LDAP_USER_OU_NAME  | OU for storing user entries. The base of user entries will be: `LDAP_BASE_DN` + `LDAP_USER_OU_NAME`    | Yes      |
+| LDAP_GROUP_OU_NAME | OU for storing group entries. The base of group entries will be: `LDAP_BASE_DN` + `LDAP_GROUP_OU_NAME` | Yes      |
+| LDAP_BIND_DN       | Distinguished Name used to bind to the LDAP server                                                     | Yes      |
+| LDAP_BIND_PWD      | Password for the LDAP bind DN                                                                          | Yes      |
 
 ### Slurm
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -32,6 +32,6 @@ ldap:
   ldap_port: 389
   ldap_base_dn: "DC=example,DC=com"
   ldap_user_ou_name: "people"
-  ldap_group_dn: "groups"
+  ldap_group_ou_name: "groups"
   ldap_bind_dn: "CN=admin,DC=example,DC=com"
   ldap_bind_password: "YOUR_LDAP_PASSWORD"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -34,4 +34,4 @@ ldap:
   ldap_user_ou_name: "people"
   ldap_group_ou_name: "groups"
   ldap_bind_dn: "CN=admin,DC=example,DC=com"
-  ldap_bind_password: "YOUR_LDAP_PASSWORD"
+  ldap_bind_pwd: "YOUR_LDAP_PASSWORD"


### PR DESCRIPTION
## Type of changes
- Docs

## Purpose
- Put `ldap_user_ou_name` and `ldap_group_ou_name` config in the example configuration.
- Document the above two setting (in environment variable) in README.

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information

<!-- Optional: Add any other information that would be helpful for the reviewer. Like detail spec, decisions, trade-offs, links, etc. -->