### PR TITLE
[CLUST-331] deploy local slurm and create accounts in slurm when creating groups

### DIFF
--- a/.deploy/local/slurm/README.md
+++ b/.deploy/local/slurm/README.md
@@ -86,7 +86,7 @@ earlier steps (LDAP groups deleted) and the DB transaction rolls back.
 Verify the REST path the backend uses, without the backend, with:
 
 ```bash
-./smoke-test.sh                       # creates account "clustron-smoke" + its assoc
+./smoke-test.sh                       # create + delete "clustron-smoke", asserting both
 # override the API version if needed:
 SLURM_RESTFUL_VERSION=v0.0.44 ./smoke-test.sh myaccount
 ```
@@ -145,7 +145,7 @@ This removes the MariaDB and Slurm state volumes, resetting all accounts.
 | `compose.yaml` | the cluster definition (prebuilt image, no build) |
 | `deploy.sh` / `cleanup.sh` | bring up (with version probe) / tear down |
 | `mint-token.sh` | mint a root or per-user JWT via `scontrol token` |
-| `smoke-test.sh` | create+read an account via the backend's REST path |
+| `smoke-test.sh` | create, read, and delete an account via the backend's REST paths (asserts deletion) |
 | `config.slurm-local.yaml` | the `slurm_*` block to paste into `config.yaml` |
 
 ## Troubleshooting

--- a/.deploy/local/slurm/README.md
+++ b/.deploy/local/slurm/README.md
@@ -64,11 +64,7 @@ slurm:                                       # MUST be nested under `slurm:`
   slurm_root_token:       "eyJhbGciOi..."    # from `make slurm-token`
 ```
 
-> **Gotcha:** these keys only load when nested under a top-level `slurm:` key.
-> Placed flat, they are silently ignored and you get
-> `Post "/slurmdb//accounts": unsupported protocol scheme ""` (empty base URL +
-> version). Also don't mix YAML and `SLURM_*` env vars — setting one env var
-> replaces the whole slurm struct, blanking the rest.
+Use `make slurm-token username=root lifespan=infinite` to get an unexpired root token.
 
 Now `make run` the backend. Creating a group will create a matching Slurm
 account (see below).

--- a/.deploy/local/slurm/README.md
+++ b/.deploy/local/slurm/README.md
@@ -1,0 +1,183 @@
+# Local Dockerized Slurm for Clustron
+
+A self-contained Slurm cluster in Docker so the backend's `internal/slurm`
+functions (account/user/association management and job submission) can be
+exercised against a **real `slurmrestd`** during local development.
+
+> **"Slurm can't run in a container" — only half true.** Production *compute
+> nodes* are awkward to containerize (they want cgroups, GPUs, MPI, privileged
+> host access). But a single-host **dev/test** cluster — `slurmctld` +
+> `slurmdbd` + `slurmrestd` + a dynamic compute node — runs in Docker just fine.
+> This stack is built on the well-maintained
+> [giovtorres/slurm-docker-cluster](https://github.com/giovtorres/slurm-docker-cluster)
+> image and needs **no source compile** (it pulls a prebuilt image).
+
+## What you get
+
+| Container | Role | Port |
+| --- | --- | --- |
+| `mysql` (MariaDB) | slurmdbd accounting storage | internal |
+| `slurmdbd` | accounting daemon; generates the shared `jwt_hs256.key` | internal `6819` |
+| `slurmctld` | controller; mints JWTs via `scontrol token` | internal `6817` |
+| `slurmrestd` | **REST API with JWT auth** (`X-SLURM-USER-TOKEN`) | **host `6820`** |
+| `cpu-worker` | one dynamic compute node so a partition exists | internal `6818` |
+
+The backend talks to `slurmrestd` exactly as it does in dev/stage:
+`POST /slurmdb/<ver>/accounts_association`, `GET /slurm/<ver>/jobs`, etc., authenticating
+with a JWT in the `X-SLURM-USER-TOKEN` header.
+
+## Prerequisites
+
+- Docker + Docker Compose (v2). On Windows, run these from your **WSL** shell.
+- Outbound network on first run (to pull `giovtorres/slurm-docker-cluster` and
+  `mariadb`).
+
+## Quick start
+
+From `clustron-backend/`:
+
+```bash
+make slurm-up          # == ./.deploy/local/slurm/deploy.sh
+make slurm-token       # prints a root JWT  (== ./.deploy/local/slurm/mint-token.sh root)
+```
+
+`make slurm-up` waits for every daemon to become healthy and then prints which
+REST API versions the running image serves, e.g.:
+
+```
+/slurm/v0.0.43
+/slurm/v0.0.44
+/slurmdb/v0.0.43
+/slurmdb/v0.0.44
+```
+
+### Point the backend at it
+
+Copy the `slurm:` block from [`config.slurm-local.yaml`](./config.slurm-local.yaml)
+into your `clustron-backend/config.yaml`, then paste the `make slurm-token`
+output into `slurm_root_token`:
+
+```yaml
+slurm:                                       # MUST be nested under `slurm:`
+  slurm_restful_base_url: "http://localhost:6820"
+  slurm_restful_version:  "v0.0.44"          # pick one from the deploy.sh output
+  slurm_root_token:       "eyJhbGciOi..."    # from `make slurm-token`
+```
+
+> **Gotcha:** these keys only load when nested under a top-level `slurm:` key.
+> Placed flat, they are silently ignored and you get
+> `Post "/slurmdb//accounts": unsupported protocol scheme ""` (empty base URL +
+> version). Also don't mix YAML and `SLURM_*` env vars — setting one env var
+> replaces the whole slurm struct, blanking the rest.
+
+Now `make run` the backend. Creating a group will create a matching Slurm
+account (see below).
+
+## The group → account flow
+
+`group.Service.Create` runs a saga: **DB group → LDAP base group → LDAP admin
+group → Slurm account**. The Slurm step calls `slurm.CreateAccountAssociation`
+(the `sacctmgr add account` equivalent — `POST /slurmdb/<ver>/accounts_association`)
+with the group's LDAP CN as the account name, so the account is created **with**
+its cluster association and is usable for jobs. (The bare `/accounts` endpoint
+creates an account with no association.) If it fails, the saga compensates the
+earlier steps (LDAP groups deleted) and the DB transaction rolls back.
+
+Verify the REST path the backend uses, without the backend, with:
+
+```bash
+./smoke-test.sh                       # creates account "clustron-smoke" + its assoc
+# override the API version if needed:
+SLURM_RESTFUL_VERSION=v0.0.44 ./smoke-test.sh myaccount
+```
+
+Inspect accounts and their associations directly inside the cluster:
+
+```bash
+docker compose exec slurmctld sacctmgr -i show account
+docker compose exec slurmctld sacctmgr -i show assoc account=clustron-smoke
+```
+
+> **Heads-up — group creation now depends on Slurm.** Because the account step
+> is part of the saga, group creation will **fail** if `slurmrestd` is
+> unreachable or `slurm_root_token` is missing/expired. Keep this stack up (and
+> the token fresh) while working on groups, or expect group creation to error.
+
+## Per-user job tokens (out of scope here)
+
+The backend's *job* endpoints need a per-user JWT from an external
+[slurm-token-helper](https://github.com/NYCU-SDC/slurm-token-helper)
+(`GET /api/token/{username}`). That integration is deferred to a separate task —
+this stack is scoped to the group → Slurm-account flow, which uses
+`slurm_root_token` and needs no helper. For ad-hoc job testing you can mint a
+per-user token straight from `scontrol`:
+
+```bash
+./mint-token.sh alice 3600
+curl -H "X-SLURM-USER-TOKEN: $(./mint-token.sh alice)" http://localhost:6820/slurm/v0.0.44/jobs
+```
+
+## Slurm version / REST API version
+
+`SLURM_VERSION` (default `25.11.4`) selects the image tag and therefore which
+OpenAPI plugins `slurmrestd` exposes. The backend's `slurm_restful_version`
+**must** match one of them. The project uses **`v0.0.44`**, which Slurm 25.11
+serves. SchedMD removes old plugin versions over time, so if you need a specific
+version, confirm it in the `make slurm-up` output and pin `SLURM_VERSION`
+accordingly:
+
+```bash
+SLURM_VERSION=25.05.6 make slurm-up   # if you specifically need an older API
+```
+
+## Teardown
+
+```bash
+make slurm-down        # == ./cleanup.sh ; stops everything and wipes volumes
+```
+
+This removes the MariaDB and Slurm state volumes, resetting all accounts.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `compose.yaml` | the cluster definition (prebuilt image, no build) |
+| `deploy.sh` / `cleanup.sh` | bring up (with version probe) / tear down |
+| `mint-token.sh` | mint a root or per-user JWT via `scontrol token` |
+| `smoke-test.sh` | create+read an account via the backend's REST path |
+| `config.slurm-local.yaml` | the `slurm_*` block to paste into `config.yaml` |
+
+## Troubleshooting
+
+**`sinfo` shows the node `down` / jobs stay `PENDING` ("Required node not
+available") after a host or Docker restart.** The compute node is dynamic
+(`slurmd -Z`); when its container restarts, slurmctld marks it
+`down` ("Node unexpectedly rebooted") and the image's `ReturnToService=1` only
+auto-returns *non-responsive* nodes. Just re-run:
+
+```bash
+make slurm-up        # resumes any down nodes and sets ReturnToService=2
+```
+
+or fix it by hand:
+
+```bash
+docker exec clustron-slurm-slurmctld scontrol update nodename=c1 state=resume
+```
+
+**`srun` fails / hangs when run as root.** Slurm refuses to run jobs as root or
+SlurmUser. Submit as a normal user inside the cluster:
+
+```bash
+docker exec clustron-slurm-slurmctld su slurm -s /bin/bash -c "srun -N1 hostname"
+```
+
+## Notes / caveats
+
+- Compute is minimal: one dynamic node, jobs may sit `PENDING`. Accounting and
+  job *submission/listing* work; this stack is not for running real workloads.
+- `slurmctld`, `slurmrestd` and the worker run `privileged: true` (Slurm needs
+  it). Fine for local dev; do not copy this layout to production.
+- The cluster is independent of the core `.deploy/local` stack (separate Compose
+  project `clustron-slurm-local`), so `make prepare`/`make run` are unaffected.

--- a/.deploy/local/slurm/README.md
+++ b/.deploy/local/slurm/README.md
@@ -64,7 +64,16 @@ slurm:                                       # MUST be nested under `slurm:`
   slurm_root_token:       "eyJhbGciOi..."    # from `make slurm-token`
 ```
 
-Use `make slurm-token username=root lifespan=infinite` to get an unexpired root token.
+By default `make slurm-token` mints a 1-hour (3600s) root token. For an
+effectively unexpired token, pass a long lifespan via `SLURM_LIFESPAN`:
+
+```bash
+make slurm-token SLURM_LIFESPAN=infinite   # exp ~year 2094 — paste once, forget
+```
+
+`SLURM_USER` and `SLURM_LIFESPAN` are forwarded to `mint-token.sh` (defaults
+`root` / `3600`), so `./.deploy/local/slurm/mint-token.sh root infinite` is the
+equivalent direct call.
 
 Now `make run` the backend. Creating a group will create a matching Slurm
 account (see below).

--- a/.deploy/local/slurm/cleanup.sh
+++ b/.deploy/local/slurm/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Stop the cluster and wipe its volumes (resets the slurmdbd accounting database).
+set -euo pipefail
+cd "$(dirname "$0")"
+echo ":: Removing Clustron local Slurm cluster and volumes ..."
+docker compose down -v

--- a/.deploy/local/slurm/compose.yaml
+++ b/.deploy/local/slurm/compose.yaml
@@ -1,0 +1,156 @@
+# Local Dockerized Slurm cluster for Clustron backend development.
+#
+# Self-contained: uses the prebuilt giovtorres/slurm-docker-cluster image
+# (no source compile). Brings up slurmdbd + slurmctld + slurmrestd (JWT auth on
+# :6820) + one dynamic compute node, backed by MariaDB for accounting.
+#
+# This lets the backend's internal/slurm functions (CreateAccount, CreateUser,
+# CreateAssociation, job submission, ...) talk to a real slurmrestd.
+#
+# Quick start (from clustron-backend/):
+#   make slurm-up        # or: ./.deploy/local/slurm/deploy.sh
+#   make slurm-token     # mint a root JWT for slurm_root_token
+# See README.md in this directory for full details.
+
+name: clustron-slurm-local
+
+x-slurm-image: &slurm-image giovtorres/slurm-docker-cluster:${SLURM_VERSION:-25.11.4}
+
+services:
+  mysql:
+    image: mariadb:12
+    hostname: mysql
+    container_name: clustron-slurm-mysql
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_DATABASE: slurm_acct_db
+      MYSQL_USER: slurm
+      MYSQL_PASSWORD: password
+    volumes:
+      - var_lib_mysql:/var/lib/mysql
+    networks:
+      - slurm-network
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  slurmdbd:
+    image: *slurm-image
+    init: true
+    command: ["slurmdbd"]
+    container_name: clustron-slurm-slurmdbd
+    hostname: slurmdbd
+    environment:
+      MYSQL_USER: slurm
+      MYSQL_PASSWORD: password
+    volumes:
+      - etc_munge:/etc/munge
+      - etc_slurm:/etc/slurm
+      - var_log_slurm:/var/log/slurm
+    expose:
+      - "6819"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      - slurm-network
+    healthcheck:
+      test: ["CMD-SHELL", "pidof slurmdbd"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  slurmctld:
+    image: *slurm-image
+    init: true
+    command: ["slurmctld"]
+    container_name: clustron-slurm-slurmctld
+    hostname: slurmctld
+    privileged: true
+    working_dir: /data
+    volumes:
+      - etc_munge:/etc/munge
+      - etc_slurm:/etc/slurm
+      - slurm_jobdir:/data
+      - var_log_slurm:/var/log/slurm
+    expose:
+      - "6817"
+    depends_on:
+      slurmdbd:
+        condition: service_healthy
+    networks:
+      - slurm-network
+    healthcheck:
+      test: ["CMD-SHELL", "scontrol ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  slurmrestd:
+    image: *slurm-image
+    init: true
+    command: ["slurmrestd"]
+    container_name: clustron-slurm-slurmrestd
+    hostname: slurmrestd
+    privileged: true
+    volumes:
+      - etc_munge:/etc/munge
+      - etc_slurm:/etc/slurm
+      - var_log_slurm:/var/log/slurm
+    ports:
+      # Host:Container. The backend's slurm_restful_base_url points here.
+      - "6820:6820"
+    depends_on:
+      slurmctld:
+        condition: service_healthy
+    networks:
+      - slurm-network
+    healthcheck:
+      test: ["CMD-SHELL", "test -S /var/run/slurmrestd/slurmrestd.socket"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  cpu-worker:
+    image: *slurm-image
+    init: true
+    command: ["slurmd-cpu"]
+    working_dir: /data
+    privileged: true
+    environment:
+      COMPOSE_PROJECT_NAME: clustron-slurm-local
+    volumes:
+      - etc_munge:/etc/munge
+      - etc_slurm:/etc/slurm
+      - slurm_jobdir:/data
+      - var_log_slurm:/var/log/slurm
+    expose:
+      - "6818"
+    depends_on:
+      slurmctld:
+        condition: service_healthy
+    networks:
+      - slurm-network
+    healthcheck:
+      test: ["CMD-SHELL", "pidof slurmd"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+volumes:
+  etc_munge:
+  etc_slurm:
+  var_log_slurm:
+  slurm_jobdir:
+  var_lib_mysql:
+
+networks:
+  slurm-network:
+    driver: bridge

--- a/.deploy/local/slurm/config.slurm-local.yaml
+++ b/.deploy/local/slurm/config.slurm-local.yaml
@@ -1,0 +1,25 @@
+# Slurm settings for the local Dockerized cluster (.deploy/local/slurm).
+#
+# IMPORTANT: these keys must be NESTED under a top-level `slurm:` key — the
+# backend maps them via `Slurm slurm.Config `yaml:"slurm"`` in internal/config.
+# Flat/top-level keys are silently ignored (you'll get empty base URL + version
+# and a `Post "/slurmdb//accounts": unsupported protocol scheme ""` error).
+#
+# Copy this whole `slurm:` block into your clustron-backend/config.yaml.
+#
+# Do NOT also set SLURM_* env vars: setting even one of them replaces the entire
+# slurm config struct (config.Merge is per-top-level-field), wiping the others.
+# Put these in ONE place — here, or as env vars.
+#
+#   slurm_restful_version: must be a version the running image serves. Slurm
+#     25.11 serves v0.0.42 / v0.0.43 / v0.0.44; `make slurm-up` prints the list.
+#   slurm_root_token: paste the output of `make slurm-token`. Tokens expire
+#     (default 1h) — re-mint when you start getting 401s.
+#
+# (slurm_token_helper_url is only needed for the per-user job endpoints, which
+# are out of scope here; it's defined-but-not-required, so it's omitted.)
+
+slurm:
+  slurm_restful_base_url: "http://localhost:6820"
+  slurm_restful_version: "v0.0.44"
+  slurm_root_token: "PASTE_OUTPUT_OF_make_slurm-token"

--- a/.deploy/local/slurm/deploy.sh
+++ b/.deploy/local/slurm/deploy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Bring up the local Slurm cluster and report the REST API version(s) it serves.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo ":: Starting Clustron local Slurm cluster (project: clustron-slurm-local) ..."
+docker compose up -d --wait mysql slurmdbd slurmctld slurmrestd cpu-worker
+
+echo ":: Probing slurmrestd on http://localhost:6820 ..."
+TOKEN="$(./mint-token.sh root 600 2>/dev/null || true)"
+if [ -n "${TOKEN}" ]; then
+  echo ":: REST API versions served (set slurm_restful_version to one of these):"
+  for v in v0.0.42 v0.0.43 v0.0.44 v0.0.45 v0.0.46; do
+    code="$(curl -s -o /dev/null -w '%{http_code}' -H "X-SLURM-USER-TOKEN: ${TOKEN}" "http://localhost:6820/slurm/${v}/ping")"
+    [ "${code}" = "200" ] && echo "   ${v}"
+  done
+fi
+
+# Resilience: after a host/Docker restart, the dynamic compute node returns DOWN
+# ("Node unexpectedly rebooted") because the image ships ReturnToService=1, which
+# only auto-returns *non-responsive* nodes. Flip it to 2 (auto-return on any
+# registration) and clear anything currently down so `make slurm-up` self-heals.
+echo ":: Ensuring compute nodes are in service ..."
+docker compose exec -T slurmctld bash -lc '
+  sed -i "s/^ReturnToService=.*/ReturnToService=2/" /etc/slurm/slurm.conf 2>/dev/null || true
+  scontrol reconfigure 2>/dev/null || true
+  for n in $(sinfo -hN -t down,drain,drained,fail -o "%N" 2>/dev/null | sort -u); do
+    scontrol update nodename="$n" state=resume reason="clustron deploy" 2>/dev/null || true
+  done
+' >/dev/null 2>&1 || true
+
+cat <<'TXT'
+
+:: Cluster is up. Next steps:
+   1. Mint a root token:   ./mint-token.sh root            (or: make slurm-token)
+   2. Put it in clustron-backend/config.yaml as slurm_root_token
+      (see ./config.slurm-local.yaml for the full slurm block)
+   3. Smoke-test account creation:  ./smoke-test.sh
+   4. Tear down:           ./cleanup.sh                     (or: make slurm-down)
+TXT

--- a/.deploy/local/slurm/mint-token.sh
+++ b/.deploy/local/slurm/mint-token.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Mint a Slurm JWT via `scontrol token` inside the running slurmctld container.
+#   ./mint-token.sh [username] [lifespan-seconds]
+# Default: username=root lifespan=3600. Use the printed value as slurm_root_token
+# (for username=root) or as a per-user X-SLURM-USER-TOKEN.
+set -euo pipefail
+cd "$(dirname "$0")"
+USERNAME="${1:-root}"
+LIFESPAN="${2:-3600}"
+docker compose exec -T slurmctld scontrol token "username=${USERNAME}" "lifespan=${LIFESPAN}" \
+  | tr -d '\r' | sed 's/^SLURM_JWT=//'

--- a/.deploy/local/slurm/smoke-test.sh
+++ b/.deploy/local/slurm/smoke-test.sh
@@ -2,8 +2,10 @@
 # Prove the backend's Slurm account path works end-to-end against slurmrestd:
 # mints a root token and creates an account via the SAME REST call the backend's
 # slurm.CreateAccountAssociation uses (POST /slurmdb/<ver>/accounts_association,
-# the `sacctmgr add account` equivalent), then confirms the account AND its
-# cluster association exist.
+# the `sacctmgr add account` equivalent), confirms the account AND its cluster
+# association exist, then deletes it via the SAME call slurm.DeleteAccount uses
+# (DELETE /slurmdb/<ver>/account/<name>) — the group saga's compensation path —
+# and confirms it's gone.
 #   ./smoke-test.sh [account-name]
 set -euo pipefail
 cd "$(dirname "$0")"
@@ -29,3 +31,22 @@ echo ":: association (proves the account is usable, not just a bare record):"
 docker compose exec -T slurmctld sacctmgr -i -n show assoc account="${ACCT}" \
   format=Account%-20,Cluster%-12,User%-12 2>/dev/null | sed "/^$/d"
 echo ":: OK if the account shows an association on a cluster above."
+echo
+
+echo ":: DELETE ${BASE}/account/${ACCT}  (== slurm.DeleteAccount, the saga's compensation)"
+curl -fsS -X DELETE "${BASE}/account/${ACCT}" -H "X-SLURM-USER-TOKEN: ${TOKEN}"
+echo
+
+echo ":: GET ${BASE}/account/${ACCT}  (expect empty accounts list)"
+GET_AFTER_DELETE="$(curl -fsS "${BASE}/account/${ACCT}" -H "X-SLURM-USER-TOKEN: ${TOKEN}")"
+echo "${GET_AFTER_DELETE}" | head -c 500
+echo
+echo ":: sacctmgr view after delete (expect no rows):"
+docker compose exec -T slurmctld sacctmgr -i -n show assoc account="${ACCT}" \
+  format=Account%-20,Cluster%-12,User%-12 2>/dev/null | sed "/^$/d"
+
+if echo "${GET_AFTER_DELETE}" | grep -q "\"name\": \"${ACCT}\""; then
+  echo ":: FAIL — account still present after delete." >&2
+  exit 1
+fi
+echo ":: OK — account deleted successfully."

--- a/.deploy/local/slurm/smoke-test.sh
+++ b/.deploy/local/slurm/smoke-test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Prove the backend's Slurm account path works end-to-end against slurmrestd:
+# mints a root token and creates an account via the SAME REST call the backend's
+# slurm.CreateAccountAssociation uses (POST /slurmdb/<ver>/accounts_association,
+# the `sacctmgr add account` equivalent), then confirms the account AND its
+# cluster association exist.
+#   ./smoke-test.sh [account-name]
+set -euo pipefail
+cd "$(dirname "$0")"
+
+VER="${SLURM_RESTFUL_VERSION:-v0.0.44}"
+ACCT="${1:-clustron-smoke}"
+BASE="http://localhost:6820/slurmdb/${VER}"
+
+echo ":: Minting root token ..."
+TOKEN="$(./mint-token.sh root 600)"
+
+echo ":: POST ${BASE}/accounts_association  (name=${ACCT})"
+curl -fsS -X POST "${BASE}/accounts_association" \
+  -H "X-SLURM-USER-TOKEN: ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"association_condition\":{\"accounts\":[\"${ACCT}\"],\"association\":{}},\"account\":{}}"
+echo
+
+echo ":: GET ${BASE}/account/${ACCT}"
+curl -fsS "${BASE}/account/${ACCT}" -H "X-SLURM-USER-TOKEN: ${TOKEN}" | head -c 1500
+echo
+echo ":: association (proves the account is usable, not just a bare record):"
+docker compose exec -T slurmctld sacctmgr -i -n show assoc account="${ACCT}" \
+  format=Account%-20,Cluster%-12,User%-12 2>/dev/null | sed "/^$/d"
+echo ":: OK if the account shows an association on a cluster above."

--- a/.deploy/local/slurm/smoke-test.sh
+++ b/.deploy/local/slurm/smoke-test.sh
@@ -1,52 +1,66 @@
 #!/usr/bin/env bash
-# Prove the backend's Slurm account path works end-to-end against slurmrestd:
-# mints a root token and creates an account via the SAME REST call the backend's
-# slurm.CreateAccountAssociation uses (POST /slurmdb/<ver>/accounts_association,
-# the `sacctmgr add account` equivalent), confirms the account AND its cluster
-# association exist, then deletes it via the SAME call slurm.DeleteAccount uses
-# (DELETE /slurmdb/<ver>/account/<name>) — the group saga's compensation path —
-# and confirms it's gone.
+# Prove the backend's Slurm account-hierarchy path works end-to-end against
+# slurmrestd. Mirrors the group sagas' exact call sequence:
+#   1. create the top-level account              (CreateSlurmTopAccount)
+#   2. create -base/-admin children under it     (CreateSlurmChildAccounts)
+#   3. verify the parent/child tree via sacctmgr
+#   4. delete admin -> base -> top               (the Delete saga's order)
+# using the SAME REST calls the backend's slurm.CreateAccountAssociation
+# (POST /slurmdb/<ver>/accounts_association) and slurm.DeleteAccount
+# (DELETE /slurmdb/<ver>/account/<name>) use.
 #   ./smoke-test.sh [account-name]
 set -euo pipefail
 cd "$(dirname "$0")"
 
 VER="${SLURM_RESTFUL_VERSION:-v0.0.44}"
-ACCT="${1:-clustron-smoke}"
+TOP="${1:-clustron-smoke}"
+BASE_ACCT="${TOP}-base"
+ADMIN_ACCT="${TOP}-admin"
 BASE="http://localhost:6820/slurmdb/${VER}"
 
 echo ":: Minting root token ..."
 TOKEN="$(./mint-token.sh root 600)"
 
-echo ":: POST ${BASE}/accounts_association  (name=${ACCT})"
+echo ":: POST ${BASE}/accounts_association  (top-level: ${TOP})"
 curl -fsS -X POST "${BASE}/accounts_association" \
   -H "X-SLURM-USER-TOKEN: ${TOKEN}" \
   -H "Content-Type: application/json" \
-  -d "{\"association_condition\":{\"accounts\":[\"${ACCT}\"],\"association\":{}},\"account\":{}}"
+  -d "{\"association_condition\":{\"accounts\":[\"${TOP}\"],\"association\":{}},\"account\":{}}"
 echo
 
-echo ":: GET ${BASE}/account/${ACCT}"
-curl -fsS "${BASE}/account/${ACCT}" -H "X-SLURM-USER-TOKEN: ${TOKEN}" | head -c 1500
-echo
-echo ":: association (proves the account is usable, not just a bare record):"
-docker compose exec -T slurmctld sacctmgr -i -n show assoc account="${ACCT}" \
-  format=Account%-20,Cluster%-12,User%-12 2>/dev/null | sed "/^$/d"
-echo ":: OK if the account shows an association on a cluster above."
+echo ":: POST ${BASE}/accounts_association  (children of ${TOP}: ${BASE_ACCT}, ${ADMIN_ACCT})"
+curl -fsS -X POST "${BASE}/accounts_association" \
+  -H "X-SLURM-USER-TOKEN: ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"association_condition\":{\"accounts\":[\"${BASE_ACCT}\",\"${ADMIN_ACCT}\"],\"association\":{\"parent\":\"${TOP}\"}},\"account\":{}}"
 echo
 
-echo ":: DELETE ${BASE}/account/${ACCT}  (== slurm.DeleteAccount, the saga's compensation)"
-curl -fsS -X DELETE "${BASE}/account/${ACCT}" -H "X-SLURM-USER-TOKEN: ${TOKEN}"
+echo ":: Account tree (expect ${BASE_ACCT} and ${ADMIN_ACCT} parented under ${TOP}):"
+TREE="$(docker compose exec -T slurmctld sacctmgr -i -n show assoc \
+  format=Account%-24,ParentName%-24,Cluster%-12 2>/dev/null | grep "${TOP}" || true)"
+echo "${TREE}"
+for CHILD in "${BASE_ACCT}" "${ADMIN_ACCT}"; do
+  if ! echo "${TREE}" | grep -q "${CHILD}[[:space:]]\{1,\}${TOP}"; then
+    echo ":: FAIL — ${CHILD} is not parented under ${TOP}." >&2
+    exit 1
+  fi
+done
+echo ":: OK — hierarchy in place."
 echo
 
-echo ":: GET ${BASE}/account/${ACCT}  (expect empty accounts list)"
-GET_AFTER_DELETE="$(curl -fsS "${BASE}/account/${ACCT}" -H "X-SLURM-USER-TOKEN: ${TOKEN}")"
-echo "${GET_AFTER_DELETE}" | head -c 500
-echo
-echo ":: sacctmgr view after delete (expect no rows):"
-docker compose exec -T slurmctld sacctmgr -i -n show assoc account="${ACCT}" \
-  format=Account%-20,Cluster%-12,User%-12 2>/dev/null | sed "/^$/d"
+echo ":: Deleting children then top (the group Delete saga's order)"
+for ACCT in "${ADMIN_ACCT}" "${BASE_ACCT}" "${TOP}"; do
+  echo ":: DELETE ${BASE}/account/${ACCT}"
+  curl -fsS -X DELETE "${BASE}/account/${ACCT}" -H "X-SLURM-USER-TOKEN: ${TOKEN}"
+  echo
+done
 
-if echo "${GET_AFTER_DELETE}" | grep -q "\"name\": \"${ACCT}\""; then
-  echo ":: FAIL — account still present after delete." >&2
-  exit 1
-fi
-echo ":: OK — account deleted successfully."
+echo ":: GET after delete (expect all three gone):"
+for ACCT in "${TOP}" "${BASE_ACCT}" "${ADMIN_ACCT}"; do
+  GET_AFTER_DELETE="$(curl -fsS "${BASE}/account/${ACCT}" -H "X-SLURM-USER-TOKEN: ${TOKEN}")"
+  if echo "${GET_AFTER_DELETE}" | grep -q "\"name\": \"${ACCT}\""; then
+    echo ":: FAIL — account ${ACCT} still present after delete." >&2
+    exit 1
+  fi
+done
+echo ":: OK — all three accounts deleted successfully."

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BLUE = \033[0;34m
 RED = \033[0;31m
 NC = \033[0m
 
-.PHONY: all prepare run build test gen
+.PHONY: all prepare run build test gen slurm-up slurm-down slurm-token
 
 all: build
 
@@ -69,3 +69,15 @@ flow-chart:
 		go-callvis -ignore "$(IGNORE_PKGS)" $(EXTRA_FLAGS) $(TARGET) || (echo -e "  -> $(RED)Execution failed$(NC)" && exit 1); \
 	fi
 	@echo -e "==> $(BLUE)Call graph generation finished$(NC)"
+
+# ---- Local Dockerized Slurm cluster (.deploy/local/slurm) ----
+SLURM_USER ?= root
+
+slurm-up:
+	@./.deploy/local/slurm/deploy.sh
+
+slurm-down:
+	@./.deploy/local/slurm/cleanup.sh
+
+slurm-token:
+	@./.deploy/local/slurm/mint-token.sh $(SLURM_USER)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ run:
 	@cd ./.deploy/local \
 		&& ./start.sh \
 		|| (echo -e "  -> $(RED)Depending services start failed. Make sure you run 'make prepare' previously.$(NC)" && exit 1)
+	@(exec 3<>/dev/tcp/localhost/6820) 2>/dev/null \
+		|| echo -e "  -> $(RED)Warning:$(NC) local Slurm cluster not reachable on :6820. Group creation and job endpoints will fail. Run 'make slurm-up' first if you need them."
 	@make gen
 	@echo -e "-> starting backend..."
 	@go build -o bin/backend cmd/backend/main.go && \

--- a/Makefile
+++ b/Makefile
@@ -82,4 +82,4 @@ slurm-down:
 	@./.deploy/local/slurm/cleanup.sh
 
 slurm-token:
-	@./.deploy/local/slurm/mint-token.sh $(SLURM_USER)
+	@./.deploy/local/slurm/mint-token.sh $(or $(SLURM_USER),root) $(or $(SLURM_LIFESPAN),3600)

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -157,8 +157,8 @@ func main() {
 	ldapGroupService := ldapgroup.NewService(logger, dbPool)
 	groupRoleService := grouprole.NewService(logger, ldapGroupService, ldapClient, dbPool)
 	memberService := membership.NewService(logger, dbPool, userService, groupRoleService, settingService, ldapGroupService, ldapClient)
-	groupService := group.NewService(logger, dbPool, userService, settingService, groupRoleService, memberService, ldapGroupService, ldapClient)
 	slurmService := slurm.NewService(logger, cfg.Slurm.SlurmTokenHelperURL, cfg.Slurm.SlurmRestfulBaseURL, cfg.Slurm.SlurmRestfulVersion, cfg.Slurm.SlurmRootToken, settingService, redisService)
+	groupService := group.NewService(logger, dbPool, userService, settingService, groupRoleService, memberService, ldapGroupService, ldapClient, slurmService)
 	jobService := job.NewService(logger, slurmService)
 	moduleService := module.NewService(logger, dbPool)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,9 +1,10 @@
 database_url: "YOUR_DATABASE_URL"
 base_url: "BASE_URL"
-slurm_token_helper_url: "TOKEN_HELPER_URL"
-slurm_restful_base_url: "RESTFUL_NODE_URL"
-slurm_restful_version: "v0.0.43"
-slurm_root_token: "YOUR_ROOT_TOKEN"
+slurm:
+  slurm_token_helper_url: "TOKEN_HELPER_URL"
+  slurm_restful_base_url: "RESTFUL_NODE_URL"
+  slurm_restful_version: "v0.0.44"
+  slurm_root_token: "YOUR_ROOT_TOKEN"
 debug:
 oauth_proxy_base_url:
 oauth_proxy_secret:

--- a/internal/group/handler.go
+++ b/internal/group/handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
 	"github.com/NYCU-SDC/summer/pkg/pagination"
@@ -255,6 +256,11 @@ func (h *Handler) CreateHandler(w http.ResponseWriter, r *http.Request) {
 	err = handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &request)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	if strings.HasSuffix(request.LDAPGroupName, "-base") || strings.HasSuffix(request.LDAPGroupName, "-admin") {
+		h.problemWriter.WriteError(traceCtx, w, handlerutil.ErrValidation, logger)
 		return
 	}
 

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -594,16 +594,20 @@ func (s *Service) Create(ctx context.Context, userID uuid.UUID, title, descripti
 		},
 	})
 
+	slurmBaseAccount := fmt.Sprintf("%s-base", baseCN)
+
 	saga.AddStep(internal.SagaStep{
-		Name: "CreateSlurmAccount",
+		Name: "CreateSlurmTopAccount",
 		Action: func(ctx context.Context) error {
-			// A Clustron group maps to a Slurm accounting account. Use the
-			// accounts_association endpoint (== `sacctmgr add account`) so the
-			// account is created *with* its cluster association and is usable;
-			// nil clusterNames associates it to slurmdbd's cluster(s).
+			// A Clustron group maps to a small Slurm account tree: a top-level
+			// account named after the group, with -base/-admin children created
+			// in the next step. The accounts_association endpoint (== `sacctmgr
+			// add account`) creates each account *with* its cluster association
+			// so it is usable; nil clusterNames associates it to slurmdbd's
+			// cluster(s).
 			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{baseCN}, nil, "")
 			if err != nil {
-				logger.Error("failed to create account in Slurm", zap.Error(err))
+				logger.Error("failed to create top-level account in Slurm", zap.Error(err))
 				span.RecordError(err)
 				return err
 			}
@@ -612,7 +616,33 @@ func (s *Service) Create(ctx context.Context, userID uuid.UUID, title, descripti
 		Compensate: func(ctx context.Context) error {
 			err := s.slurmStore.DeleteAccount(ctx, baseCN)
 			if err != nil {
-				logger.Error("failed to delete account in Slurm", zap.Error(err))
+				logger.Error("failed to delete top-level account in Slurm", zap.Error(err))
+			}
+			return err
+		},
+	})
+
+	saga.AddStep(internal.SagaStep{
+		Name: "CreateSlurmChildAccounts",
+		Action: func(ctx context.Context) error {
+			// The admin child reuses the LDAP admin CN (<name>-admin); the base
+			// child needs its own -base suffix because the top-level account
+			// already took the bare group name.
+			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{slurmBaseAccount, adminCN}, nil, baseCN)
+			if err != nil {
+				logger.Error("failed to create base/admin child accounts in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(ctx context.Context) error {
+			err := errors.Join(
+				s.slurmStore.DeleteAccount(ctx, adminCN),
+				s.slurmStore.DeleteAccount(ctx, slurmBaseAccount),
+			)
+			if err != nil {
+				logger.Error("failed to delete base/admin child accounts in Slurm", zap.Error(err))
 			}
 			return err
 		},

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -831,25 +831,74 @@ func (s *Service) Delete(ctx context.Context, groupID uuid.UUID) error {
 		},
 	})
 
-	// Step 3: Delete the Slurm Account
+	slurmBaseAccount := fmt.Sprintf("%s-base", baseCN)
+
+	// Steps 3-5: tear down the group's Slurm account tree children-first —
+	// slurmdbd refuses to delete an account that still has child associations.
+	// One saga step per account so a failure compensates exactly what was
+	// already deleted.
 	saga.AddStep(internal.SagaStep{
-		Name: "Delete Slurm Account",
+		Name: "Delete Slurm Admin Account",
 		Action: func(c context.Context) error {
-			err = s.slurmStore.DeleteAccount(c, baseCN)
+			err := s.slurmStore.DeleteAccount(c, adminCN)
 			if err != nil {
-				s.logger.Error("failed to delete account in Slurm", zap.Error(err))
+				s.logger.Error("failed to delete admin account in Slurm", zap.Error(err))
 				span.RecordError(err)
 				return err
 			}
 			return nil
 		},
 		Compensate: func(c context.Context) error {
-			// Compensation: recreate the account (with its association) if a
-			// later step fails.
-			s.logger.Info("Compensating: Recreating Slurm Account", zap.String("account", baseCN))
-			_, err = s.slurmStore.CreateAccountAssociation(c, []string{baseCN}, nil, "")
+			s.logger.Info("Compensating: Recreating Slurm admin account", zap.String("account", adminCN))
+			_, err := s.slurmStore.CreateAccountAssociation(c, []string{adminCN}, nil, baseCN)
 			if err != nil {
-				s.logger.Error("failed to compensate for creating account in Slurm", zap.Error(err))
+				s.logger.Error("failed to compensate for creating admin account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+	})
+
+	saga.AddStep(internal.SagaStep{
+		Name: "Delete Slurm Base Account",
+		Action: func(c context.Context) error {
+			err := s.slurmStore.DeleteAccount(c, slurmBaseAccount)
+			if err != nil {
+				s.logger.Error("failed to delete base account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(c context.Context) error {
+			s.logger.Info("Compensating: Recreating Slurm base account", zap.String("account", slurmBaseAccount))
+			_, err := s.slurmStore.CreateAccountAssociation(c, []string{slurmBaseAccount}, nil, baseCN)
+			if err != nil {
+				s.logger.Error("failed to compensate for creating base account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+	})
+
+	saga.AddStep(internal.SagaStep{
+		Name: "Delete Slurm Top Account",
+		Action: func(c context.Context) error {
+			err := s.slurmStore.DeleteAccount(c, baseCN)
+			if err != nil {
+				s.logger.Error("failed to delete top-level account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(c context.Context) error {
+			s.logger.Info("Compensating: Recreating Slurm top-level account", zap.String("account", baseCN))
+			_, err := s.slurmStore.CreateAccountAssociation(c, []string{baseCN}, nil, "")
+			if err != nil {
+				s.logger.Error("failed to compensate for creating top-level account in Slurm", zap.Error(err))
 				span.RecordError(err)
 				return err
 			}

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -5,6 +5,7 @@ import (
 	"clustron-backend/internal/grouprole"
 	"clustron-backend/internal/jwt"
 	"clustron-backend/internal/setting"
+	"clustron-backend/internal/slurm"
 	"clustron-backend/internal/user"
 	"clustron-backend/internal/user/role"
 	"context"
@@ -73,7 +74,7 @@ type LDAPClient interface {
 // jobs (the bare /accounts endpoint leaves it with no association). Members are
 // later added as Slurm users via the users_association endpoint.
 type SlurmStore interface {
-	CreateAccountAssociation(ctx context.Context, accountNames, clusterNames []string) error
+	CreateAccountAssociation(ctx context.Context, accountNames, clusterNames []string) (slurm.ParsedAccountAssociationResponse, error)
 	DeleteAccount(ctx context.Context, accountName string) error
 }
 
@@ -598,7 +599,7 @@ func (s *Service) Create(ctx context.Context, userID uuid.UUID, title, descripti
 			// accounts_association endpoint (== `sacctmgr add account`) so the
 			// account is created *with* its cluster association and is usable;
 			// nil clusterNames associates it to slurmdbd's cluster(s).
-			err := s.slurmStore.CreateAccountAssociation(ctx, []string{baseCN}, nil)
+			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{baseCN}, nil)
 			if err != nil {
 				logger.Error("failed to create account in Slurm", zap.Error(err))
 				span.RecordError(err)
@@ -814,7 +815,7 @@ func (s *Service) Delete(ctx context.Context, groupID uuid.UUID) error {
 			// Compensation: recreate the account (with its association) if a
 			// later step fails.
 			s.logger.Info("Compensating: Recreating Slurm Account", zap.String("account", baseCN))
-			err = s.slurmStore.CreateAccountAssociation(c, []string{baseCN}, nil)
+			_, err = s.slurmStore.CreateAccountAssociation(c, []string{baseCN}, nil)
 			if err != nil {
 				s.logger.Error("failed to compensate for creating account in Slurm", zap.Error(err))
 				span.RecordError(err)

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -798,7 +798,33 @@ func (s *Service) Delete(ctx context.Context, groupID uuid.UUID) error {
 		},
 	})
 
-	// 3. Execute the Saga
+	// Step 3: Delete the Slurm Account
+	saga.AddStep(internal.SagaStep{
+		Name: "Delete Slurm Account",
+		Action: func(c context.Context) error {
+			err = s.slurmStore.DeleteAccount(c, baseCN)
+			if err != nil {
+				s.logger.Error("failed to delete account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(c context.Context) error {
+			// Compensation: recreate the account (with its association) if a
+			// later step fails.
+			s.logger.Info("Compensating: Recreating Slurm Account", zap.String("account", baseCN))
+			err = s.slurmStore.CreateAccountAssociation(c, []string{baseCN}, nil)
+			if err != nil {
+				s.logger.Error("failed to compensate for creating account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+	})
+
+	// 4. Execute the Saga
 	if err := saga.Execute(traceCtx); err != nil { //
 		s.logger.Error("Failed to delete LDAP groups, saga aborted/compensated", zap.Error(err))
 		span.RecordError(err)

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -561,7 +561,8 @@ func (s *Service) Create(ctx context.Context, userID uuid.UUID, title, descripti
 			return nil
 		},
 		Compensate: func(ctx context.Context) error {
-			err := s.ldapClient.DeleteGroup(title)
+			// Delete the group we actually created (baseCN), not the title.
+			err := s.ldapClient.DeleteGroup(baseCN)
 			if err != nil {
 				logger.Error("failed to delete group in LDAP", zap.Error(err))
 			}

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -67,6 +67,16 @@ type LDAPClient interface {
 	GetGroupInfo(groupName string) (*ldap.Entry, error)
 }
 
+// SlurmStore manages the Slurm accounting "account" that mirrors a Clustron
+// group. CreateAccountAssociation is the `sacctmgr add account` equivalent: it
+// creates the account AND its cluster association, so the account is usable for
+// jobs (the bare /accounts endpoint leaves it with no association). Members are
+// later added as Slurm users via the users_association endpoint.
+type SlurmStore interface {
+	CreateAccountAssociation(ctx context.Context, accountNames, clusterNames []string) error
+	DeleteAccount(ctx context.Context, accountName string) error
+}
+
 type Service struct {
 	logger         *zap.Logger
 	tracer         trace.Tracer
@@ -78,9 +88,10 @@ type Service struct {
 	memberStore    MembershipStore
 	ldapGroupStore LDAPGroupStore
 	ldapClient     LDAPClient
+	slurmStore     SlurmStore
 }
 
-func NewService(logger *zap.Logger, db *pgxpool.Pool, userStore UserStore, settingStore SettingStore, roleStore RoleStore, membershipStore MembershipStore, ldapGroupStore LDAPGroupStore, ldapClient LDAPClient) *Service {
+func NewService(logger *zap.Logger, db *pgxpool.Pool, userStore UserStore, settingStore SettingStore, roleStore RoleStore, membershipStore MembershipStore, ldapGroupStore LDAPGroupStore, ldapClient LDAPClient, slurmStore SlurmStore) *Service {
 	return &Service{
 		logger:         logger,
 		tracer:         otel.Tracer("group/service"),
@@ -92,6 +103,7 @@ func NewService(logger *zap.Logger, db *pgxpool.Pool, userStore UserStore, setti
 		memberStore:    membershipStore,
 		ldapGroupStore: ldapGroupStore,
 		ldapClient:     ldapClient,
+		slurmStore:     slurmStore,
 	}
 }
 
@@ -573,6 +585,30 @@ func (s *Service) Create(ctx context.Context, userID uuid.UUID, title, descripti
 			err := s.ldapClient.DeleteGroup(adminCN)
 			if err != nil {
 				logger.Error("failed to delete group in LDAP", zap.Error(err))
+			}
+			return err
+		},
+	})
+
+	saga.AddStep(internal.SagaStep{
+		Name: "CreateSlurmAccount",
+		Action: func(ctx context.Context) error {
+			// A Clustron group maps to a Slurm accounting account. Use the
+			// accounts_association endpoint (== `sacctmgr add account`) so the
+			// account is created *with* its cluster association and is usable;
+			// nil clusterNames associates it to slurmdbd's cluster(s).
+			err := s.slurmStore.CreateAccountAssociation(ctx, []string{baseCN}, nil)
+			if err != nil {
+				logger.Error("failed to create account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(ctx context.Context) error {
+			err := s.slurmStore.DeleteAccount(ctx, baseCN)
+			if err != nil {
+				logger.Error("failed to delete account in Slurm", zap.Error(err))
 			}
 			return err
 		},

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -68,13 +68,15 @@ type LDAPClient interface {
 	GetGroupInfo(groupName string) (*ldap.Entry, error)
 }
 
-// SlurmStore manages the Slurm accounting "account" that mirrors a Clustron
-// group. CreateAccountAssociation is the `sacctmgr add account` equivalent: it
-// creates the account AND its cluster association, so the account is usable for
-// jobs (the bare /accounts endpoint leaves it with no association). Members are
+// SlurmStore manages the Slurm accounting hierarchy that mirrors a Clustron
+// group: a top-level account named after the group with -base/-admin child
+// accounts. CreateAccountAssociation is the `sacctmgr add account` equivalent:
+// it creates the accounts AND their cluster associations, so they are usable
+// for jobs (the bare /accounts endpoint leaves them with no association); a
+// non-empty parent nests the accounts under that parent account. Members are
 // later added as Slurm users via the users_association endpoint.
 type SlurmStore interface {
-	CreateAccountAssociation(ctx context.Context, accountNames, clusterNames []string) (slurm.ParsedAccountAssociationResponse, error)
+	CreateAccountAssociation(ctx context.Context, accountNames, clusterNames []string, parent string) (slurm.ParsedAccountAssociationResponse, error)
 	DeleteAccount(ctx context.Context, accountName string) error
 }
 
@@ -599,7 +601,7 @@ func (s *Service) Create(ctx context.Context, userID uuid.UUID, title, descripti
 			// accounts_association endpoint (== `sacctmgr add account`) so the
 			// account is created *with* its cluster association and is usable;
 			// nil clusterNames associates it to slurmdbd's cluster(s).
-			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{baseCN}, nil)
+			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{baseCN}, nil, "")
 			if err != nil {
 				logger.Error("failed to create account in Slurm", zap.Error(err))
 				span.RecordError(err)
@@ -815,7 +817,7 @@ func (s *Service) Delete(ctx context.Context, groupID uuid.UUID) error {
 			// Compensation: recreate the account (with its association) if a
 			// later step fails.
 			s.logger.Info("Compensating: Recreating Slurm Account", zap.String("account", baseCN))
-			_, err = s.slurmStore.CreateAccountAssociation(c, []string{baseCN}, nil)
+			_, err = s.slurmStore.CreateAccountAssociation(c, []string{baseCN}, nil, "")
 			if err != nil {
 				s.logger.Error("failed to compensate for creating account in Slurm", zap.Error(err))
 				span.RecordError(err)

--- a/internal/saga.go
+++ b/internal/saga.go
@@ -33,13 +33,16 @@ func (s *Saga) Execute(ctx context.Context) error {
 		if err := step.Action(ctx); err != nil {
 			s.logger.Error("Saga step failed", zap.String("step", step.Name), zap.Error(err))
 
+			// Best-effort rollback: compensate every executed step in reverse,
+			// even if an individual compensation fails (otherwise a single
+			// failure would leave the remaining steps un-compensated). The
+			// original action error is returned as the cause.
 			for i := len(executedSteps) - 1; i >= 0; i-- {
 				if executedSteps[i].Compensate == nil {
 					continue
 				}
 				if rollbackErr := executedSteps[i].Compensate(ctx); rollbackErr != nil {
 					s.logger.Error("Compensation step failed", zap.String("step", executedSteps[i].Name), zap.Error(rollbackErr))
-					return rollbackErr
 				}
 			}
 			return err

--- a/internal/saga_test.go
+++ b/internal/saga_test.go
@@ -1,0 +1,76 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// On action failure, every previously-executed step is compensated in reverse
+// order, and Execute returns the original action error (not nil, not a
+// compensation error).
+func TestSaga_RollsBackInReverseOnActionFailure(t *testing.T) {
+	var order []string
+	wantErr := errors.New("action boom")
+
+	s := NewSaga(zap.NewNop())
+	s.AddStep(SagaStep{
+		Name:       "step1",
+		Action:     func(context.Context) error { return nil },
+		Compensate: func(context.Context) error { order = append(order, "comp1"); return nil },
+	})
+	s.AddStep(SagaStep{
+		Name:       "step2",
+		Action:     func(context.Context) error { return nil },
+		Compensate: func(context.Context) error { order = append(order, "comp2"); return nil },
+	})
+	s.AddStep(SagaStep{
+		Name:   "step3",
+		Action: func(context.Context) error { return wantErr },
+	})
+
+	err := s.Execute(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("want original action error, got %v", err)
+	}
+	if len(order) != 2 || order[0] != "comp2" || order[1] != "comp1" {
+		t.Fatalf("want reverse-order compensation [comp2 comp1], got %v", order)
+	}
+}
+
+// A failing compensation must not prevent the remaining steps from being
+// compensated (best-effort rollback). Regression test for the early-return bug.
+func TestSaga_BestEffortRollbackContinuesAfterCompensationFailure(t *testing.T) {
+	var compensated []string
+	wantErr := errors.New("action boom")
+
+	s := NewSaga(zap.NewNop())
+	s.AddStep(SagaStep{
+		Name:       "step1",
+		Action:     func(context.Context) error { return nil },
+		Compensate: func(context.Context) error { compensated = append(compensated, "comp1"); return nil },
+	})
+	s.AddStep(SagaStep{
+		Name:   "step2",
+		Action: func(context.Context) error { return nil },
+		Compensate: func(context.Context) error {
+			compensated = append(compensated, "comp2")
+			return errors.New("compensation boom")
+		},
+	})
+	s.AddStep(SagaStep{
+		Name:   "step3",
+		Action: func(context.Context) error { return wantErr },
+	})
+
+	err := s.Execute(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("want original action error, got %v", err)
+	}
+	// comp2 fails, but comp1 must still be attempted.
+	if len(compensated) != 2 || compensated[0] != "comp2" || compensated[1] != "comp1" {
+		t.Fatalf("want both compensations attempted [comp2 comp1], got %v", compensated)
+	}
+}

--- a/internal/slurm/service.go
+++ b/internal/slurm/service.go
@@ -782,7 +782,10 @@ func (s *Service) CreateUserAssociation(ctx context.Context, userNames, accountN
 	return parsedResponse, nil
 }
 
-func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, clusterNames []string) (ParsedAccountAssociationResponse, error) {
+// CreateAccountAssociation is the `sacctmgr add account` equivalent: it creates
+// the accounts AND their cluster associations in one call. A non-empty parent
+// places the accounts under that parent account; empty means under root.
+func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, clusterNames []string, parent string) (ParsedAccountAssociationResponse, error) {
 	traceCtx, span := s.tracer.Start(ctx, "CreateAccountAssociation")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -791,8 +794,9 @@ func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, cl
 
 	request := AccountAssociationRequest{
 		AssociationCondition: AccountAddCondition{
-			Accounts: accountNames,
-			Clusters: clusterNames,
+			Accounts:    accountNames,
+			Clusters:    clusterNames,
+			Association: AssociationRecSet{Parent: parent},
 		},
 		Account: AccountShort{},
 	}

--- a/internal/slurm/service.go
+++ b/internal/slurm/service.go
@@ -829,7 +829,7 @@ func (s *Service) CreateAccountAssociation(ctx context.Context, accountNames, cl
 	// Catch standard HTTP errors (e.g., 401 Unauthorized, 404 Not Found)
 	if response.StatusCode != http.StatusOK {
 		err = fmt.Errorf("unexpected http status code: %d", response.StatusCode)
-		logger.Error("failed to create Slurm user association", zap.Error(err))
+		logger.Error("failed to create Slurm account association", zap.Error(err))
 		span.RecordError(err)
 		return ParsedAccountAssociationResponse{}, err
 	}

--- a/internal/slurm/service_test.go
+++ b/internal/slurm/service_test.go
@@ -1,9 +1,15 @@
 package slurm
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestParseUserAssociationResponse(t *testing.T) {
@@ -90,6 +96,49 @@ func TestParseAccountAssociationResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseAccountAssociationResponse(tt.input)
 			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestCreateAccountAssociationParent(t *testing.T) {
+	tests := []struct {
+		name       string
+		parent     string
+		wantParent string // "" means the field must be absent from the request
+	}{
+		{name: "with parent", parent: "proj101", wantParent: "proj101"},
+		{name: "without parent keeps account under root", parent: "", wantParent: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, "/slurmdb/v0.0.44/accounts_association", r.URL.Path)
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"added_accounts": " Adding Account(s)\n  proj101-base\n", "errors": [], "warnings": []}`))
+			}))
+			defer server.Close()
+
+			svc := NewService(zap.NewNop(), "", server.URL, "v0.0.44", "root-token", nil, nil)
+
+			resp, err := svc.CreateAccountAssociation(context.Background(), []string{"proj101-base"}, nil, tt.parent)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"proj101-base"}, resp.AddedAccounts)
+
+			cond, ok := gotBody["association_condition"].(map[string]any)
+			require.True(t, ok, "request must contain association_condition")
+			assert.Equal(t, []any{"proj101-base"}, cond["accounts"])
+
+			assoc, _ := cond["association"].(map[string]any)
+			if tt.wantParent == "" {
+				_, present := assoc["parent"]
+				assert.False(t, present, "parent must be omitted when empty")
+			} else {
+				assert.Equal(t, tt.wantParent, assoc["parent"])
+			}
 		})
 	}
 }

--- a/internal/slurm/service_test.go
+++ b/internal/slurm/service_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestParseUserAssociationResponse(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		name     string
 		input    string
 		expected ParsedUserAssociationResponse
@@ -49,16 +49,16 @@ func TestParseUserAssociationResponse(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := ParseUserAssociationResponse(tt.input)
-			assert.Equal(t, tt.expected, got)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseUserAssociationResponse(tc.input)
+			assert.Equal(t, tc.expected, got)
 		})
 	}
 }
 
 func TestParseAccountAssociationResponse(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		name     string
 		input    string
 		expected ParsedAccountAssociationResponse
@@ -92,26 +92,40 @@ func TestParseAccountAssociationResponse(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := ParseAccountAssociationResponse(tt.input)
-			assert.Equal(t, tt.expected, got)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseAccountAssociationResponse(tc.input)
+			assert.Equal(t, tc.expected, got)
 		})
 	}
 }
 
 func TestCreateAccountAssociationParent(t *testing.T) {
-	tests := []struct {
-		name       string
-		parent     string
-		wantParent string // "" means the field must be absent from the request
+	testCases := []struct {
+		name             string
+		accounts         []string
+		parent           string
+		expectedAccounts []any
+		expectedParent   any // value of association_condition.association.parent; nil means the field must be omitted
 	}{
-		{name: "with parent", parent: "proj101", wantParent: "proj101"},
-		{name: "without parent keeps account under root", parent: "", wantParent: ""},
+		{
+			name:             "with parent nests the accounts under it",
+			accounts:         []string{"proj101-base", "proj101-admin"},
+			parent:           "proj101",
+			expectedAccounts: []any{"proj101-base", "proj101-admin"},
+			expectedParent:   "proj101",
+		},
+		{
+			name:             "without parent keeps the account under root",
+			accounts:         []string{"proj101"},
+			parent:           "",
+			expectedAccounts: []any{"proj101"},
+			expectedParent:   nil,
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			var gotBody map[string]any
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, http.MethodPost, r.Method)
@@ -124,21 +138,17 @@ func TestCreateAccountAssociationParent(t *testing.T) {
 
 			svc := NewService(zap.NewNop(), "", server.URL, "v0.0.44", "root-token", nil, nil)
 
-			resp, err := svc.CreateAccountAssociation(context.Background(), []string{"proj101-base"}, nil, tt.parent)
+			resp, err := svc.CreateAccountAssociation(context.Background(), tc.accounts, nil, tc.parent)
 			require.NoError(t, err)
 			assert.Equal(t, []string{"proj101-base"}, resp.AddedAccounts)
 
 			cond, ok := gotBody["association_condition"].(map[string]any)
 			require.True(t, ok, "request must contain association_condition")
-			assert.Equal(t, []any{"proj101-base"}, cond["accounts"])
+			assert.Equal(t, tc.expectedAccounts, cond["accounts"])
 
-			assoc, _ := cond["association"].(map[string]any)
-			if tt.wantParent == "" {
-				_, present := assoc["parent"]
-				assert.False(t, present, "parent must be omitted when empty")
-			} else {
-				assert.Equal(t, tt.wantParent, assoc["parent"])
-			}
+			assoc, ok := cond["association"].(map[string]any)
+			require.True(t, ok, "request must contain association_condition.association")
+			assert.Equal(t, tc.expectedParent, assoc["parent"])
 		})
 	}
 }

--- a/internal/slurm/service_test.go
+++ b/internal/slurm/service_test.go
@@ -1,4 +1,4 @@
-package slurm
+package slurm_test
 
 import (
 	"context"
@@ -7,16 +7,32 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"clustron-backend/internal/config"
+	"clustron-backend/internal/slurm"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
+func testSlurmAPIVersion(t *testing.T) string {
+	t.Helper()
+
+	cfg, _ := config.Load()
+	version := cfg.Slurm.SlurmRestfulVersion
+	if version == "" {
+		version = "v0.0.44"
+	}
+
+	require.NotEmpty(t, version)
+	return version
+}
+
 func TestParseUserAssociationResponse(t *testing.T) {
 	testCases := []struct {
 		name     string
 		input    string
-		expected ParsedUserAssociationResponse
+		expected slurm.ParsedUserAssociationResponse
 	}{
 		{
 			name: "valid user association response with multiple users and associations",
@@ -29,11 +45,11 @@ func TestParseUserAssociationResponse(t *testing.T) {
 				` Associations\n` +
 				`  C = head       A = testaccount                U = user1     \n` +
 				`  C = head       A = testaccount                U = user2     \n`,
-			expected: ParsedUserAssociationResponse{
+			expected: slurm.ParsedUserAssociationResponse{
 				AddedUsers:     []string{"user1", "user2"},
 				DefaultAccount: "testaccount",
 				AdminLevel:     "None",
-				Associations: []Association{
+				Associations: []slurm.Association{
 					{User: "user1", Account: "testaccount", Cluster: "head"},
 					{User: "user2", Account: "testaccount", Cluster: "head"},
 				},
@@ -42,7 +58,7 @@ func TestParseUserAssociationResponse(t *testing.T) {
 		{
 			name:  "empty or empty lines only",
 			input: "\n\n",
-			expected: ParsedUserAssociationResponse{
+			expected: slurm.ParsedUserAssociationResponse{
 				AddedUsers:   nil,
 				Associations: nil,
 			},
@@ -51,7 +67,7 @@ func TestParseUserAssociationResponse(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ParseUserAssociationResponse(tc.input)
+			got := slurm.ParseUserAssociationResponse(tc.input)
 			assert.Equal(t, tc.expected, got)
 		})
 	}
@@ -61,7 +77,7 @@ func TestParseAccountAssociationResponse(t *testing.T) {
 	testCases := []struct {
 		name     string
 		input    string
-		expected ParsedAccountAssociationResponse
+		expected slurm.ParsedAccountAssociationResponse
 	}{
 		{
 			name: "valid account association response",
@@ -72,11 +88,11 @@ func TestParseAccountAssociationResponse(t *testing.T) {
 				`  Organization = testorg\n` +
 				` Associations\n` +
 				`  A = acc1       C = dev-cluster\n`,
-			expected: ParsedAccountAssociationResponse{
+			expected: slurm.ParsedAccountAssociationResponse{
 				AddedAccounts: []string{"acc1"},
 				Description:   "test account description",
 				Organization:  "testorg",
-				Associations: []Association{
+				Associations: []slurm.Association{
 					{Account: "acc1", Cluster: "dev-cluster"},
 				},
 			},
@@ -86,7 +102,7 @@ func TestParseAccountAssociationResponse(t *testing.T) {
 			input: `freeform message to ignore\n` +
 				` Adding Account(s)\n` +
 				`  acc2\n`,
-			expected: ParsedAccountAssociationResponse{
+			expected: slurm.ParsedAccountAssociationResponse{
 				AddedAccounts: []string{"acc2"},
 			},
 		},
@@ -94,7 +110,7 @@ func TestParseAccountAssociationResponse(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ParseAccountAssociationResponse(tc.input)
+			got := slurm.ParseAccountAssociationResponse(tc.input)
 			assert.Equal(t, tc.expected, got)
 		})
 	}
@@ -123,20 +139,21 @@ func TestCreateAccountAssociationParent(t *testing.T) {
 			expectedParent:   nil,
 		},
 	}
+	apiVersion := testSlurmAPIVersion(t)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var gotBody map[string]any
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, http.MethodPost, r.Method)
-				require.Equal(t, "/slurmdb/v0.0.44/accounts_association", r.URL.Path)
+				require.Equal(t, "/slurmdb/"+apiVersion+"/accounts_association", r.URL.Path)
 				require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"added_accounts": " Adding Account(s)\n  proj101-base\n", "errors": [], "warnings": []}`))
 			}))
 			defer server.Close()
 
-			svc := NewService(zap.NewNop(), "", server.URL, "v0.0.44", "root-token", nil, nil)
+			svc := slurm.NewService(zap.NewNop(), "", server.URL, apiVersion, "root-token", nil, nil)
 
 			resp, err := svc.CreateAccountAssociation(context.Background(), tc.accounts, nil, tc.parent)
 			require.NoError(t, err)


### PR DESCRIPTION
## Type of changes
- Feature
- Fix
- Chore
- Test

## Purpose
- Add Slurm account provisioning to the group lifecycle: creating a group now provisions a **three-account hierarchy** — a top-level account named after the group's LDAP name with `-base` and `-admin` children under it (via `accounts_association`, the `sacctmgr add account` equivalent — the bare `/accounts` endpoint leaves an account with no cluster association and is unusable for jobs); deleting a group tears the tree down children-first. All of it runs as saga steps with compensation, mirroring the existing LDAP steps.

  ```
  root
  └── <ldapName>            top-level account
      ├── <ldapName>-base   base account  (regular members)
      └── <ldapName>-admin  admin account (matches the LDAP admin CN)
  ```
- `slurm.CreateAccountAssociation` gains a `parent string` parameter, sent as `association_condition.association.parent`; empty string keeps the account under root, so existing behavior is expressible unchanged.
- Add a local Dockerized Slurm cluster (`.deploy/local/slurm/`) so `internal/slurm` — previously untestable locally — can run against a real `slurmrestd`. `make slurm-up` / `slurm-down` / `slurm-token`; `make run` now does a fast, non-fatal reachability check and warns if the local cluster isn't up.
- Fix a latent group-creation rollback bug: the base LDAP group's compensation deleted `title` (a display string) instead of the group actually created (`baseCN`), orphaning it on rollback.
- Make saga rollback best-effort (`internal/saga.go`): previously, one failing compensation aborted all remaining compensations; now every executed step is compensated in reverse regardless, and the original action error is still returned. This benefits every saga in the codebase (group, membership, grouprole, setting).
- Fix `config.example.yaml`: the `slurm_*` keys were listed flat, but the config loader only reads them nested under a `slurm:` key, so they were silently ignored (empty base URL/version → `unsupported protocol scheme ""`).

## Additional Information

**Design notes**
- Account naming: the top-level account takes the bare LDAP group name, so the base child needs its own `-base` suffix; the admin child reuses the LDAP admin CN (`<name>-admin`). Slurm account names are global, so top and child can't share a name.
- Deletion is three saga steps (admin → base → top), one per account, because `Saga.Execute` only compensates fully completed steps — a mid-bundle failure would otherwise leave an already-deleted account un-compensated. Children go first because slurmdbd refuses to delete an account that still has child associations.
- `CreateAccountAssociation`/`DeleteAccount` use the root token (`slurm_root_token`); the per-user token-helper integration is untouched by this PR and deferred to a separate task — job endpoints (`GetJobs`, `CreateJob`, etc.) aren't affected here.
- Associating individual users with the base/admin child accounts is out of scope (no membership code calls `users_association` yet), as is migrating Slurm accounts for pre-existing groups.
- The local Slurm stack uses the prebuilt [`giovtorres/slurm-docker-cluster`](https://github.com/giovtorres/slurm-docker-cluster) image (no source build) — daemon-only (slurmdbd/slurmctld/slurmrestd + one dynamic compute node), which is fine for exercising the REST API even though a full production compute cluster isn't a good container fit.
- **Behavior change:** group creation now hard-depends on Slurm being reachable — if `slurmrestd` is down or the root token is expired, group creation fails (by saga design, consistent with the existing LDAP-dependency behavior).
- `Archive`/`Unarchive` deliberately do **not** touch the Slurm accounts (only toggle LDAP membership), so the account tree persists through an archive/unarchive cycle — worth reviewer confirmation this is the intended semantics.

**Validation**
- Added `internal/saga_test.go` (previously no saga tests): reverse-order rollback, and a regression test for the best-effort-continues-after-compensation-failure fix.
- Added `TestCreateAccountAssociationParent` (httptest against a fake `slurmrestd`): asserts the request carries `association_condition.association.parent` when a parent is given and omits it when empty.
- `make test` (full suite incl. group integration tests) and `golangci-lint run` both pass clean.
- End-to-end validated against the local Slurm cluster: `.deploy/local/slurm/smoke-test.sh` now replays the sagas' exact sequence — creates the top account, creates both children under it, verifies the parent/child tree via `sacctmgr show assoc` (ParentName column), then deletes admin → base → top and asserts all three are gone.
