### PR TITLE
fix: use ldapCN as simple allowed group reference

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -162,7 +162,7 @@ func main() {
 	groupService := group.NewService(logger, dbPool, userService, settingService, groupRoleService, memberService, ldapGroupService, ldapClient, slurmService)
 	jobService := job.NewService(logger, slurmService)
 	moduleService := module.NewService(logger, dbPool)
-	ansibleService := ansible.NewService(logger, dbPool, cfg.LDAP)
+	ansibleService := ansible.NewService(logger, dbPool, cfg.LDAP, ldapGroupService)
 
 	// Set memberService in settingService after all dependencies are created
 	settingService.SetMembershipService(memberService)

--- a/internal/ansible/handler.go
+++ b/internal/ansible/handler.go
@@ -66,17 +66,17 @@ type Store interface {
 	ResetNode(ctx context.Context, id uuid.UUID) (Server, error)
 	UpdateRole(ctx context.Context, id uuid.UUID, role string) (Server, error)
 	ListAllowedLoginGroups(ctx context.Context, serverID uuid.UUID) ([]AllowedLoginGroupDetail, error)
-	SetAllowedLoginGroups(ctx context.Context, serverID uuid.UUID, groupIDs []uuid.UUID) error
+	SetAllowedLoginGroups(ctx context.Context, serverID uuid.UUID, ldapGroupIDs []uuid.UUID) error
 }
 
 type UpdateAllowedLoginGroupsRequest struct {
-	GroupIDs []string `json:"groupIds" validate:"required,dive,uuid"`
+	LDAPGroupIDs []string `json:"ldapGroupIds" validate:"required,dive,uuid"`
 }
 
 type AllowedLoginGroupResponse struct {
-	GroupID string `json:"groupId"`
-	Title   string `json:"title"`
-	LdapCN  string `json:"ldapCn"`
+	LDAPGroupID string `json:"ldapGroupId"`
+	Title       string `json:"title"`
+	LDAPCN      string `json:"ldapCn"`
 }
 
 type Handler struct {
@@ -247,9 +247,9 @@ func (h *Handler) GetAllowedLoginGroups(w http.ResponseWriter, r *http.Request) 
 	responses := make([]AllowedLoginGroupResponse, len(groups))
 	for i, g := range groups {
 		responses[i] = AllowedLoginGroupResponse{
-			GroupID: g.GroupID.String(),
-			Title:   g.Title,
-			LdapCN:  g.LdapCN,
+			LDAPGroupID: g.LDAPGroupID.String(),
+			Title:       g.Title,
+			LDAPCN:      g.LdapCN,
 		}
 	}
 	handlerutil.WriteJSONResponse(w, http.StatusOK, responses)
@@ -271,17 +271,17 @@ func (h *Handler) UpdateAllowedLoginGroups(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	groupIDs := make([]uuid.UUID, len(req.GroupIDs))
-	for i, raw := range req.GroupIDs {
+	ldapGroupIDs := make([]uuid.UUID, len(req.LDAPGroupIDs))
+	for i, raw := range req.LDAPGroupIDs {
 		id, err := uuid.Parse(raw)
 		if err != nil {
 			h.problemWriter.WriteError(traceCtx, w, err, logger)
 			return
 		}
-		groupIDs[i] = id
+		ldapGroupIDs[i] = id
 	}
 
-	if err := h.store.SetAllowedLoginGroups(traceCtx, serverID, groupIDs); err != nil {
+	if err := h.store.SetAllowedLoginGroups(traceCtx, serverID, ldapGroupIDs); err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
 		return
 	}

--- a/internal/ansible/handler_test.go
+++ b/internal/ansible/handler_test.go
@@ -20,6 +20,24 @@ type addNodesStore struct {
 	gotParams []CreateParams
 }
 
+type allowedLoginGroupsStore struct {
+	Store
+	gotServerID     uuid.UUID
+	gotLDAPGroupIDs []uuid.UUID
+	groups          []AllowedLoginGroupDetail
+}
+
+func (s *allowedLoginGroupsStore) SetAllowedLoginGroups(_ context.Context, serverID uuid.UUID, ldapGroupIDs []uuid.UUID) error {
+	s.gotServerID = serverID
+	s.gotLDAPGroupIDs = ldapGroupIDs
+	return nil
+}
+
+func (s *allowedLoginGroupsStore) ListAllowedLoginGroups(_ context.Context, serverID uuid.UUID) ([]AllowedLoginGroupDetail, error) {
+	s.gotServerID = serverID
+	return s.groups, nil
+}
+
 func (s *addNodesStore) AddNodes(_ context.Context, params []CreateParams) ([]Server, error) {
 	s.gotParams = params
 	servers := make([]Server, len(params))
@@ -85,5 +103,71 @@ func TestHandlerAddNodes(t *testing.T) {
 		if server.Status != "provisioning" {
 			t.Errorf("server %q status = %q, want provisioning", server.AnsibleName, server.Status)
 		}
+	}
+}
+
+func TestHandlerUpdateAllowedLoginGroupsUsesLDAPGroupIDs(t *testing.T) {
+	serverID := uuid.New()
+	ldapGroupIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	store := &allowedLoginGroupsStore{}
+	handler := NewHandler(store, validator.New(), zap.NewNop(), internal.NewProblemWriter())
+	body, err := json.Marshal(UpdateAllowedLoginGroupsRequest{
+		LDAPGroupIDs: []string{ldapGroupIDs[0].String(), ldapGroupIDs[1].String()},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/servers/"+serverID.String()+"/allowedLoginGroups", bytes.NewReader(body))
+	req.SetPathValue("server_id", serverID.String())
+	recorder := httptest.NewRecorder()
+
+	handler.UpdateAllowedLoginGroups(recorder, req)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusNoContent, recorder.Body.String())
+	}
+	if store.gotServerID != serverID {
+		t.Fatalf("server ID = %s, want %s", store.gotServerID, serverID)
+	}
+	if len(store.gotLDAPGroupIDs) != len(ldapGroupIDs) {
+		t.Fatalf("LDAP group IDs length = %d, want %d", len(store.gotLDAPGroupIDs), len(ldapGroupIDs))
+	}
+	for i := range ldapGroupIDs {
+		if store.gotLDAPGroupIDs[i] != ldapGroupIDs[i] {
+			t.Errorf("LDAP group ID %d = %s, want %s", i, store.gotLDAPGroupIDs[i], ldapGroupIDs[i])
+		}
+	}
+}
+
+func TestHandlerGetAllowedLoginGroupsReturnsLDAPGroupID(t *testing.T) {
+	serverID := uuid.New()
+	ldapGroupID := uuid.New()
+	store := &allowedLoginGroupsStore{groups: []AllowedLoginGroupDetail{{
+		LDAPGroupID: ldapGroupID,
+		Title:       "Research",
+		LdapCN:      "research-base",
+	}}}
+	handler := NewHandler(store, validator.New(), zap.NewNop(), internal.NewProblemWriter())
+	req := httptest.NewRequest(http.MethodGet, "/api/servers/"+serverID.String()+"/allowedLoginGroups", nil)
+	req.SetPathValue("server_id", serverID.String())
+	recorder := httptest.NewRecorder()
+
+	handler.GetAllowedLoginGroups(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var response []map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := response[0]["ldapGroupId"]; got != ldapGroupID.String() {
+		t.Errorf("ldapGroupId = %v, want %s", got, ldapGroupID)
+	}
+	if _, exists := response[0]["groupId"]; exists {
+		t.Error("legacy groupId field is still present")
+	}
+	if got := response[0]["ldapCn"]; got != "research-base" {
+		t.Errorf("ldapCn = %v, want research-base", got)
 	}
 }

--- a/internal/ansible/queries.sql
+++ b/internal/ansible/queries.sql
@@ -47,18 +47,17 @@ SELECT * FROM servers WHERE slurm_partition = $1 ORDER BY ansible_name;
 -- name: ListByStatus :many
 SELECT * FROM servers WHERE status = $1 ORDER BY ansible_name;
 
--- name: ListAllowedLoginGroupCNsByServerID :many
-SELECT lg.ldap_cn
-FROM allowed_login_groups alg
-JOIN ldap_groups lg ON lg.group_id = alg.group_id AND lg.type = 'BASE'
-WHERE alg.server_id = $1 AND lg.ldap_cn IS NOT NULL
-ORDER BY lg.ldap_cn;
+-- name: ListAllowedLoginGroupIDsByServerID :many
+SELECT ldap_group_id
+FROM allowed_login_groups
+WHERE server_id = $1
+ORDER BY ldap_group_id;
 
 -- name: ListServerAllowedLoginGroups :many
-SELECT alg.group_id, g.title, lg.ldap_cn
+SELECT alg.ldap_group_id, g.title, lg.ldap_cn
 FROM allowed_login_groups alg
-JOIN groups g ON g.id = alg.group_id
-JOIN ldap_groups lg ON lg.group_id = alg.group_id AND lg.type = 'BASE'
+JOIN ldap_groups lg ON lg.id = alg.ldap_group_id
+JOIN groups g ON g.id = lg.group_id
 WHERE alg.server_id = $1
 ORDER BY g.title;
 
@@ -66,12 +65,9 @@ ORDER BY g.title;
 DELETE FROM allowed_login_groups WHERE server_id = $1;
 
 -- name: AddServerAllowedLoginGroup :exec
-INSERT INTO allowed_login_groups (server_id, group_id)
+INSERT INTO allowed_login_groups (server_id, ldap_group_id)
 VALUES ($1, $2)
 ON CONFLICT DO NOTHING;
 
 -- name: ExistServerAllowedLoginGroup :one
 SELECT EXISTS (SELECT 1 FROM allowed_login_groups WHERE server_id = $1) AS exists;
-
--- name: ExistBaseLdapGroup :one
-SELECT EXISTS (SELECT 1 FROM ldap_groups WHERE group_id = $1 AND type = 'BASE') AS exists;

--- a/internal/ansible/schema.sql
+++ b/internal/ansible/schema.sql
@@ -52,8 +52,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS servers_private_ip_key ON servers(private_ip) 
 -- rendered into SSSD's simple_allow_groups
 CREATE TABLE IF NOT EXISTS allowed_login_groups
 (
-    server_id UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
-    group_id  UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    server_id      UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
+    ldap_group_id  UUID NOT NULL REFERENCES ldap_groups(id) ON DELETE CASCADE,
 
-    PRIMARY KEY (server_id, group_id)
+    PRIMARY KEY (server_id, ldap_group_id)
 );

--- a/internal/ansible/service.go
+++ b/internal/ansible/service.go
@@ -20,7 +20,6 @@ import (
 	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
 	logutil "github.com/NYCU-SDC/summer/pkg/log"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -34,7 +33,7 @@ import (
 )
 
 const (
-	ExecuteFolder		= "internal/ansible/ansible"
+	ExecuteFolder       = "internal/ansible/ansible"
 	InventoryFile       = "hosts.yaml"
 	MainPlaybook        = "playbooks/nodes.yaml"
 	UpdateRolesPlaybook = "playbooks/update_roles.yaml"
@@ -47,12 +46,17 @@ const (
 )
 
 type Service struct {
-	db         *pgxpool.Pool
-	queries    *Queries
-	logger     *zap.Logger
-	tracer     trace.Tracer
-	ldapConfig ldap.Config
-	ansibleMu  sync.Mutex
+	db             *pgxpool.Pool
+	queries        *Queries
+	logger         *zap.Logger
+	tracer         trace.Tracer
+	ldapConfig     ldap.Config
+	ldapGroupStore LDAPGroupStore
+	ansibleMu      sync.Mutex
+}
+
+type LDAPGroupStore interface {
+	GetLDAPGroupCNByID(ctx context.Context, ldapGroupID uuid.UUID) (string, error)
 }
 
 type ServiceInterface interface {
@@ -61,13 +65,14 @@ type ServiceInterface interface {
 	AddNodes(ctx context.Context, params []CreateParams) ([]Server, error)
 }
 
-func NewService(logger *zap.Logger, db *pgxpool.Pool, ldapConfig ldap.Config) *Service {
+func NewService(logger *zap.Logger, db *pgxpool.Pool, ldapConfig ldap.Config, ldapGroupStore LDAPGroupStore) *Service {
 	return &Service{
-		db:         db,
-		queries:    New(db),
-		logger:     logger,
-		tracer:     otel.Tracer("ansible/service"),
-		ldapConfig: ldapConfig,
+		db:             db,
+		queries:        New(db),
+		logger:         logger,
+		tracer:         otel.Tracer("ansible/service"),
+		ldapConfig:     ldapConfig,
+		ldapGroupStore: ldapGroupStore,
 	}
 }
 
@@ -628,8 +633,8 @@ func (s *Service) SetupAllNodes(ctx context.Context) error {
 	return nil
 }
 
-// ListAllowedLoginGroups returns the Clustron groups whose members are allowed to log in
-// to a server (rendered into that server's SSSD simple_allow_groups).
+// ListAllowedLoginGroups returns the LDAP groups whose members are allowed to log in to a
+// server. Each LDAP group ID maps to the ldap_cn rendered in SSSD simple_allow_groups.
 func (s *Service) ListAllowedLoginGroups(ctx context.Context, serverID uuid.UUID) ([]AllowedLoginGroupDetail, error) {
 	traceCtx, span := s.tracer.Start(ctx, "ListAllowedLoginGroups")
 	defer span.End()
@@ -647,18 +652,17 @@ func (s *Service) ListAllowedLoginGroups(ctx context.Context, serverID uuid.UUID
 	result := make([]AllowedLoginGroupDetail, 0, len(rows))
 	for _, row := range rows {
 		result = append(result, AllowedLoginGroupDetail{
-			GroupID: row.GroupID,
-			Title:   row.Title,
-			LdapCN:  row.LdapCn.String,
+			LDAPGroupID: row.LdapGroupID,
+			Title:       row.Title,
+			LdapCN:      row.LdapCn.String,
 		})
 	}
 	return result, nil
 }
 
-// SetAllowedLoginGroups replaces a server's allowed-login-group list with the given groups,
-// then re-renders that server's sssd.conf in the background. Each group must already have a
-// BASE LDAP group (i.e. a usable ldap_cn), otherwise the update is rejected.
-func (s *Service) SetAllowedLoginGroups(ctx context.Context, serverID uuid.UUID, groupIDs []uuid.UUID) error {
+// SetAllowedLoginGroups replaces a server's allowed-login-group list with the given LDAP
+// groups, then re-renders that server's sssd.conf in the background.
+func (s *Service) SetAllowedLoginGroups(ctx context.Context, serverID uuid.UUID, ldapGroupIDs []uuid.UUID) error {
 	traceCtx, span := s.tracer.Start(ctx, "SetAllowedLoginGroups")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -667,18 +671,12 @@ func (s *Service) SetAllowedLoginGroups(ctx context.Context, serverID uuid.UUID,
 	if err != nil {
 		return databaseutil.WrapDBError(err, logger, "get server by id")
 	}
-	if err = validateAllowedLoginGroupTarget(server.AnsibleRole, groupIDs); err != nil {
+	if err = validateAllowedLoginGroupTarget(server.AnsibleRole, ldapGroupIDs); err != nil {
 		return err
 	}
 
-	for _, id := range groupIDs {
-		exist, err := s.queries.ExistBaseLdapGroup(traceCtx, id)
-		if err != nil {
-			return databaseutil.WrapDBError(err, logger, "check base ldap group exists")
-		}
-		if !exist {
-			return databaseutil.WrapDBErrorWithKeyValue(pgx.ErrNoRows, "ldap_groups", "group_id", id.String(), logger, "find base ldap group for allowed login group")
-		}
+	if _, err = s.resolveLDAPGroupCNs(traceCtx, ldapGroupIDs); err != nil {
+		return err
 	}
 
 	tx, err := s.db.Begin(traceCtx)
@@ -691,10 +689,10 @@ func (s *Service) SetAllowedLoginGroups(ctx context.Context, serverID uuid.UUID,
 	if err = qtx.ClearServerAllowedLoginGroups(traceCtx, serverID); err != nil {
 		return databaseutil.WrapDBError(err, logger, "clear allowed login groups")
 	}
-	for _, id := range groupIDs {
+	for _, id := range ldapGroupIDs {
 		if err = qtx.AddServerAllowedLoginGroup(traceCtx, AddServerAllowedLoginGroupParams{
-			ServerID: serverID,
-			GroupID:  id,
+			ServerID:    serverID,
+			LdapGroupID: id,
 		}); err != nil {
 			return mapAllowedLoginGroupError(err, serverID, id, logger)
 		}
@@ -716,19 +714,31 @@ func (s *Service) SetAllowedLoginGroups(ctx context.Context, serverID uuid.UUID,
 	return nil
 }
 
-func mapAllowedLoginGroupError(err error, serverID, groupID uuid.UUID, logger *zap.Logger) error {
+func mapAllowedLoginGroupError(err error, serverID, ldapGroupID uuid.UUID, logger *zap.Logger) error {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) && pgErr.Code == databaseutil.PGErrForeignKeyViolation {
 		if pgErr.ConstraintName == "allowed_login_groups_server_id_fkey" {
 			return handlerutil.NewNotFoundError("servers", "id", serverID.String(), "")
 		}
-		return handlerutil.NewNotFoundError("groups", "id", groupID.String(), "")
+		return handlerutil.NewNotFoundError("ldap_groups", "id", ldapGroupID.String(), "")
 	}
 	return databaseutil.WrapDBError(err, logger, "add allowed login group")
 }
 
-func validateAllowedLoginGroupTarget(role string, groupIDs []uuid.UUID) error {
-	if role != computeNodeRole && len(groupIDs) > 0 {
+func (s *Service) resolveLDAPGroupCNs(ctx context.Context, ldapGroupIDs []uuid.UUID) ([]string, error) {
+	cns := make([]string, 0, len(ldapGroupIDs))
+	for _, id := range ldapGroupIDs {
+		cn, err := s.ldapGroupStore.GetLDAPGroupCNByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		cns = append(cns, cn)
+	}
+	return cns, nil
+}
+
+func validateAllowedLoginGroupTarget(role string, ldapGroupIDs []uuid.UUID) error {
+	if role != computeNodeRole && len(ldapGroupIDs) > 0 {
 		return internal.ErrAllowedLoginGroupsUnsupported
 	}
 	return nil
@@ -783,8 +793,8 @@ func (s *Service) generateInventory(ctx context.Context) error {
 
 		hostVars := HostVars{
 			UserName: srv.SshUser.String,
-			CPUCores:    srv.CpuCores.Int32,
-			MemoryMB:    srv.MemoryMb.Int32,
+			CPUCores: srv.CpuCores.Int32,
+			MemoryMB: srv.MemoryMb.Int32,
 		}
 
 		if srv.IpAddress.Valid {
@@ -804,15 +814,13 @@ func (s *Service) generateInventory(ctx context.Context) error {
 			hostVars.SlurmPartition = srv.SlurmPartition.String
 		}
 
-		allowedCNs, err := s.queries.ListAllowedLoginGroupCNsByServerID(ctx, srv.ID)
+		ldapGroupIDs, err := s.queries.ListAllowedLoginGroupIDsByServerID(ctx, srv.ID)
 		if err != nil {
-			return databaseutil.WrapDBError(err, s.logger, "list allowed login group cns")
+			return databaseutil.WrapDBError(err, s.logger, "list allowed LDAP group IDs")
 		}
-		cns := make([]string, 0, len(allowedCNs))
-		for _, cn := range allowedCNs {
-			if cn.Valid && cn.String != "" {
-				cns = append(cns, cn.String)
-			}
+		cns, err := s.resolveLDAPGroupCNs(ctx, ldapGroupIDs)
+		if err != nil {
+			return err
 		}
 		hostVars.LDAPSimpleAllowGroups = strings.Join(cns, ", ")
 

--- a/internal/ansible/service_test.go
+++ b/internal/ansible/service_test.go
@@ -1,6 +1,7 @@
 package ansible
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -47,19 +48,19 @@ func TestDuplicateServerField(t *testing.T) {
 
 func TestMapAllowedLoginGroupError(t *testing.T) {
 	serverID := uuid.New()
-	groupID := uuid.New()
+	ldapGroupID := uuid.New()
 	tests := []struct {
 		name       string
 		constraint string
 		wantValue  string
 	}{
 		{name: "server removed", constraint: "allowed_login_groups_server_id_fkey", wantValue: serverID.String()},
-		{name: "group removed", constraint: "allowed_login_groups_group_id_fkey", wantValue: groupID.String()},
+		{name: "LDAP group removed", constraint: "allowed_login_groups_ldap_group_id_fkey", wantValue: ldapGroupID.String()},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := mapAllowedLoginGroupError(&pgconn.PgError{Code: "23503", ConstraintName: tt.constraint}, serverID, groupID, zap.NewNop())
+			err := mapAllowedLoginGroupError(&pgconn.PgError{Code: "23503", ConstraintName: tt.constraint}, serverID, ldapGroupID, zap.NewNop())
 			if !errors.Is(err, handlerutil.ErrNotFound) {
 				t.Fatalf("mapAllowedLoginGroupError() error = %v, want ErrNotFound", err)
 			}
@@ -67,6 +68,39 @@ func TestMapAllowedLoginGroupError(t *testing.T) {
 				t.Fatalf("mapAllowedLoginGroupError() error = %q, want value %q", err, tt.wantValue)
 			}
 		})
+	}
+}
+
+type ldapGroupStoreStub struct {
+	cns map[uuid.UUID]string
+	got []uuid.UUID
+}
+
+func (s *ldapGroupStoreStub) GetLDAPGroupCNByID(_ context.Context, ldapGroupID uuid.UUID) (string, error) {
+	s.got = append(s.got, ldapGroupID)
+	return s.cns[ldapGroupID], nil
+}
+
+func TestResolveLDAPGroupCNs(t *testing.T) {
+	ldapGroupIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	store := &ldapGroupStoreStub{cns: map[uuid.UUID]string{
+		ldapGroupIDs[0]: "research-base",
+		ldapGroupIDs[1]: "cluster-admin",
+	}}
+	service := &Service{ldapGroupStore: store}
+
+	cns, err := service.resolveLDAPGroupCNs(context.Background(), ldapGroupIDs)
+	if err != nil {
+		t.Fatalf("resolveLDAPGroupCNs() error = %v", err)
+	}
+	want := []string{"research-base", "cluster-admin"}
+	if len(cns) != len(want) {
+		t.Fatalf("CNs length = %d, want %d", len(cns), len(want))
+	}
+	for i := range want {
+		if cns[i] != want[i] {
+			t.Errorf("CN %d = %q, want %q", i, cns[i], want[i])
+		}
 	}
 }
 

--- a/internal/ansible/type.go
+++ b/internal/ansible/type.go
@@ -2,28 +2,28 @@ package ansible
 
 import "github.com/google/uuid"
 
-// AllowedLoginGroupDetail is a Clustron group whose members are allowed to log in to compute
-// nodes. It maps to one entry in SSSD's simple_allow_groups (via the group's BASE ldap_cn).
+// AllowedLoginGroupDetail is an LDAP group whose members are allowed to log in to compute
+// nodes. Its LDAPGroupID resolves to the ldap_cn rendered in SSSD's simple_allow_groups.
 type AllowedLoginGroupDetail struct {
-	GroupID uuid.UUID
-	Title   string
-	LdapCN  string
+	LDAPGroupID uuid.UUID
+	Title       string
+	LdapCN      string
 }
 
 type InventoryFiles struct {
 	All ServerGroup `yaml:"all"`
 }
 type ServerGroup struct {
-	Vars     map[string]interface{}  `yaml:"vars,omitempty"`
-	Children map[string]ChildNode `yaml:"children,omitempty"`
+	Vars     map[string]interface{} `yaml:"vars,omitempty"`
+	Children map[string]ChildNode   `yaml:"children,omitempty"`
 }
 type ChildNode struct {
 	Hosts map[string]HostVars `yaml:"hosts,omitempty"`
 }
 type HostVars struct {
-	HostName			  string `yaml:"ansible_host,omitempty"`
+	HostName              string `yaml:"ansible_host,omitempty"`
 	UserName              string `yaml:"ansible_user,omitempty"`
-	SSHKeyPath		      string `yaml:"ansible_ssh_private_key_file,omitempty"`
+	SSHKeyPath            string `yaml:"ansible_ssh_private_key_file,omitempty"`
 	PrivateIP             string `yaml:"private_ip,omitempty"`
 	CPUCores              int32  `yaml:"cpu_cores,omitempty"`
 	MemoryMB              int32  `yaml:"memory_mb,omitempty"`

--- a/internal/database/migrations/20260518000000_create_servers.up.sql
+++ b/internal/database/migrations/20260518000000_create_servers.up.sql
@@ -51,8 +51,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS servers_private_ip_key ON servers(private_ip) 
 
 CREATE TABLE IF NOT EXISTS allowed_login_groups
 (
-    server_id UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
-    group_id  UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    server_id     UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
+    ldap_group_id UUID NOT NULL REFERENCES ldap_groups(id) ON DELETE CASCADE,
 
-    PRIMARY KEY (server_id, group_id)
+    PRIMARY KEY (server_id, ldap_group_id)
 );

--- a/internal/group/ldapgroup/queries.sql
+++ b/internal/group/ldapgroup/queries.sql
@@ -3,3 +3,8 @@ SELECT ldap_cn FROM ldap_groups WHERE group_id = $1 AND type = 'BASE';
 
 -- name: GetLDAPAdminGroupCNByGroupID :one
 SELECT ldap_cn FROM ldap_groups WHERE group_id = $1 AND type = 'ADMIN';
+
+-- name: GetLDAPGroupCNByID :one
+SELECT ldap_cn
+FROM ldap_groups
+WHERE id = $1 AND ldap_cn IS NOT NULL AND ldap_cn <> '';

--- a/internal/group/ldapgroup/service.go
+++ b/internal/group/ldapgroup/service.go
@@ -57,3 +57,19 @@ func (s *Service) GetLDAPAdminGroupCNByGroupID(ctx context.Context, groupID uuid
 
 	return cn.String, nil
 }
+
+func (s *Service) GetLDAPGroupCNByID(ctx context.Context, ldapGroupID uuid.UUID) (string, error) {
+	traceCtx, span := s.tracer.Start(ctx, "GetLDAPGroupCNByID")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, s.logger)
+
+	cn, err := s.queries.GetLDAPGroupCNByID(traceCtx, ldapGroupID)
+	if err != nil {
+		err = databaseutil.WrapDBErrorWithKeyValue(err, "ldap_groups", "id", ldapGroupID.String(), logger, "get LDAP group CN by ID")
+		logger.Error("failed to get LDAP group CN by ID", zap.String("ldap_group_id", ldapGroupID.String()), zap.Error(err))
+		span.RecordError(err)
+		return "", err
+	}
+
+	return cn.String, nil
+}


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Change DB relationship from group to ldap_group
- Use ldap service rather than using queries
- Write ldap group to sssd.conf
- Modified APIs.

## Additional Information

DB was changed without migration.