### PR TITLE
[CLUST-348] remove Slurm accounts when archiving groups

### DIFF
--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -1051,6 +1051,8 @@ func (s *Service) Archive(ctx context.Context, groupID uuid.UUID) (Group, error)
 		})
 	}
 
+	// Tear down the group's Slurm account tree children-first — slurmdbd
+	// refuses to delete an account that still has child associations.
 	slurmBaseAccount := slurm.BaseAccountName(baseCN)
 
 	saga.AddStep(internal.SagaStep{

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -1179,6 +1179,51 @@ func (s *Service) Unarchive(ctx context.Context, groupID uuid.UUID) (Group, erro
 		},
 	})
 
+	slurmBaseAccount := slurm.BaseAccountName(baseCN)
+
+	saga.AddStep(internal.SagaStep{
+		Name: "CreateSlurmTopAccount",
+		Action: func(ctx context.Context) error {
+			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{baseCN}, nil, "")
+			if err != nil {
+				logger.Error("failed to create top-level account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(ctx context.Context) error {
+			err := s.slurmStore.DeleteAccount(ctx, baseCN)
+			if err != nil {
+				logger.Error("failed to delete top-level account in Slurm", zap.Error(err))
+			}
+			return err
+		},
+	})
+
+	saga.AddStep(internal.SagaStep{
+		Name: "CreateSlurmChildAccounts",
+		Action: func(ctx context.Context) error {
+			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{slurmBaseAccount, adminCN}, nil, baseCN)
+			if err != nil {
+				logger.Error("failed to create base/admin child accounts in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(ctx context.Context) error {
+			err := errors.Join(
+				s.slurmStore.DeleteAccount(ctx, adminCN),
+				s.slurmStore.DeleteAccount(ctx, slurmBaseAccount),
+			)
+			if err != nil {
+				logger.Error("failed to delete base/admin child accounts in Slurm", zap.Error(err))
+			}
+			return err
+		},
+	})
+
 	for _, member := range members {
 		saga.AddStep(internal.SagaStep{
 			Name: "AddUsersToLDAPGroup",

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -1051,6 +1051,68 @@ func (s *Service) Archive(ctx context.Context, groupID uuid.UUID) (Group, error)
 		})
 	}
 
+	slurmBaseAccount := slurm.BaseAccountName(baseCN)
+
+	saga.AddStep(internal.SagaStep{
+		Name: "DeleteSlurmAdminAccount",
+		Action: func(ctx context.Context) error {
+			err := s.slurmStore.DeleteAccount(ctx, adminCN)
+			if err != nil {
+				logger.Error("failed to delete admin account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(ctx context.Context) error {
+			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{adminCN}, nil, baseCN)
+			if err != nil {
+				logger.Error("failed to compensate for creating admin account in Slurm", zap.Error(err))
+			}
+			return err
+		},
+	})
+
+	saga.AddStep(internal.SagaStep{
+		Name: "DeleteSlurmBaseAccount",
+		Action: func(ctx context.Context) error {
+			err := s.slurmStore.DeleteAccount(ctx, slurmBaseAccount)
+			if err != nil {
+				logger.Error("failed to delete base account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(ctx context.Context) error {
+			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{slurmBaseAccount}, nil, baseCN)
+			if err != nil {
+				logger.Error("failed to compensate for creating base account in Slurm", zap.Error(err))
+			}
+			return err
+		},
+	})
+
+	saga.AddStep(internal.SagaStep{
+		Name: "DeleteSlurmTopAccount",
+		Action: func(ctx context.Context) error {
+			err := s.slurmStore.DeleteAccount(ctx, baseCN)
+			if err != nil {
+				logger.Error("failed to delete top-level account in Slurm", zap.Error(err))
+				span.RecordError(err)
+				return err
+			}
+			return nil
+		},
+		Compensate: func(ctx context.Context) error {
+			_, err := s.slurmStore.CreateAccountAssociation(ctx, []string{baseCN}, nil, "")
+			if err != nil {
+				logger.Error("failed to compensate for creating top-level account in Slurm", zap.Error(err))
+			}
+			return err
+		},
+	})
+
 	err = saga.Execute(traceCtx)
 	if err != nil {
 		s.logger.Error("saga execution failed", zap.Error(err))


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose

**Why:** Archived groups currently retain their Slurm accounts, meaning they still have access to compute resources. An archived group should not be able to submit jobs.

**What:** Delete a group's Slurm account tree when archiving, and recreate it when unarchiving — so archived groups lose compute access and unarchived groups regain it.

**How:** Added saga steps to the existing `Archive` and `Unarchive` methods in `internal/group/service.go`:
- **Archive** — after removing LDAP users, deletes the Slurm account tree children-first (admin → base → top), mirroring the existing `Delete` method's pattern
- **Unarchive** — after unarchiving the DB record, recreates the Slurm account tree top-first then children, mirroring the existing `Create` method's pattern

Both use the saga pattern with compensation callbacks for rollback on failure.

## Additional Information

- No interface changes (`Store`, `SlurmStore` signatures unchanged)
- No handler changes needed
- Slurm account hierarchy: top-level (`<group-cn>`) → children (`<group-cn>-base`, `<group-cn>-admin`)
- Deletion order is children-first because slurmdbd refuses to delete an account with child associations
- The saga compensation logic mirrors what `Create` and `Delete` already do, ensuring consistency across all group lifecycle operations