### PR TITLE
Feat/assign partitions to groups by admin

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -272,6 +272,8 @@ func main() {
 	mux.HandleFunc("PATCH /api/servers/{server_id}/role", authMiddleware.HandlerFunc(ansibleHandler.UpdateRole))
 	mux.HandleFunc("GET /api/servers/{server_id}/allowedLoginGroups", authMiddleware.HandlerFunc(ansibleHandler.GetAllowedLoginGroups))
 	mux.HandleFunc("PUT /api/servers/{server_id}/allowedLoginGroups", authMiddleware.HandlerFunc(ansibleHandler.UpdateAllowedLoginGroups))
+	mux.HandleFunc("GET /api/partitions/{partition_name}/allowedGroups", authMiddleware.HandlerFunc(ansibleHandler.GetPartitionAllowedGroups))
+	mux.HandleFunc("PUT /api/partitions/{partition_name}/allowedGroups", authMiddleware.HandlerFunc(ansibleHandler.UpdatePartitionAllowedGroups))
 
 	// Modules
 	mux.HandleFunc("GET /api/modules", authMiddleware.HandlerFunc(moduleHandler.List))

--- a/internal/ansible/ansible/roles/slurm_controller/templates/slurm.conf.j2
+++ b/internal/ansible/ansible/roles/slurm_controller/templates/slurm.conf.j2
@@ -50,7 +50,9 @@ NodeName={{ host }} NodeAddr={{ node_addr }} CPUs={{ hostvars[host].cpu_cores | 
     {% endif %}
 {% endfor %}
 
+{% set allowed_accounts = slurm_partition_allowed_accounts | default({}) %}
 {% for p_name, nodes in partitions.items() %}
-PartitionName={{ p_name }} Nodes={{ nodes }} Default={% if loop.first %}YES{% else %}NO{% endif %} MaxTime=INFINITE State=UP
+PartitionName={{ p_name }} Nodes={{ nodes }} Default={% if loop.first %}YES{% else %}NO{% endif %} MaxTime=INFINITE State=UP{% if allowed_accounts.get(p_name) %} AllowAccounts={{ allowed_accounts[p_name] | join(',') }}{% endif %}
+
 {% endfor %}
 {% endif %}

--- a/internal/ansible/handler.go
+++ b/internal/ansible/handler.go
@@ -56,6 +56,7 @@ type UpdateRoleRequest struct {
 	AnsibleRole string `json:"ansible_role" validate:"required,oneof=head_nodes compute_nodes"`
 }
 
+//mockery:generate: true
 type Store interface {
 	ListAll(ctx context.Context) ([]Server, error)
 	AddNode(ctx context.Context, params CreateParams) (Server, error)

--- a/internal/ansible/handler.go
+++ b/internal/ansible/handler.go
@@ -68,13 +68,27 @@ type Store interface {
 	UpdateRole(ctx context.Context, id uuid.UUID, role string) (Server, error)
 	ListAllowedLoginGroups(ctx context.Context, serverID uuid.UUID) ([]AllowedLoginGroupDetail, error)
 	SetAllowedLoginGroups(ctx context.Context, serverID uuid.UUID, groupIDs []uuid.UUID) error
+	ListPartitionAllowedGroups(ctx context.Context, partitionName string) ([]PartitionAllowedGroupDetail, error)
+	SetPartitionAllowedGroups(ctx context.Context, partitionName string, groupIDs []uuid.UUID) error
 }
 
 type UpdateAllowedLoginGroupsRequest struct {
 	GroupIDs []string `json:"groupIds" validate:"required,dive,uuid"`
 }
 
+// UpdatePartitionAllowedGroupsRequest omits `required` so that an empty list is a valid way to
+// re-open a partition to every group.
+type UpdatePartitionAllowedGroupsRequest struct {
+	GroupIDs []string `json:"groupIds" validate:"dive,uuid"`
+}
+
 type AllowedLoginGroupResponse struct {
+	GroupID string `json:"groupId"`
+	Title   string `json:"title"`
+	LdapCN  string `json:"ldapCn"`
+}
+
+type PartitionAllowedGroupResponse struct {
 	GroupID string `json:"groupId"`
 	Title   string `json:"title"`
 	LdapCN  string `json:"ldapCn"`
@@ -283,6 +297,60 @@ func (h *Handler) UpdateAllowedLoginGroups(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := h.store.SetAllowedLoginGroups(traceCtx, serverID, groupIDs); err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) GetPartitionAllowedGroups(w http.ResponseWriter, r *http.Request) {
+	traceCtx, span := h.tracer.Start(r.Context(), "GetPartitionAllowedGroups")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, h.logger)
+
+	partitionName := r.PathValue("partition_name")
+
+	groups, err := h.store.ListPartitionAllowedGroups(traceCtx, partitionName)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	responses := make([]PartitionAllowedGroupResponse, len(groups))
+	for i, g := range groups {
+		responses[i] = PartitionAllowedGroupResponse{
+			GroupID: g.GroupID.String(),
+			Title:   g.Title,
+			LdapCN:  g.LdapCN,
+		}
+	}
+	handlerutil.WriteJSONResponse(w, http.StatusOK, responses)
+}
+
+func (h *Handler) UpdatePartitionAllowedGroups(w http.ResponseWriter, r *http.Request) {
+	traceCtx, span := h.tracer.Start(r.Context(), "UpdatePartitionAllowedGroups")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, h.logger)
+
+	partitionName := r.PathValue("partition_name")
+
+	var req UpdatePartitionAllowedGroupsRequest
+	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	groupIDs := make([]uuid.UUID, len(req.GroupIDs))
+	for i, raw := range req.GroupIDs {
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			h.problemWriter.WriteError(traceCtx, w, err, logger)
+			return
+		}
+		groupIDs[i] = id
+	}
+
+	if err := h.store.SetPartitionAllowedGroups(traceCtx, partitionName, groupIDs); err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
 		return
 	}

--- a/internal/ansible/handler_test.go
+++ b/internal/ansible/handler_test.go
@@ -3,10 +3,12 @@ package ansible_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
 	"github.com/NYCU-SDC/summer/pkg/problem"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
@@ -17,6 +19,21 @@ import (
 	"clustron-backend/internal/ansible"
 	ansiblemocks "clustron-backend/internal/ansible/mocks"
 )
+
+func newTestHandler(store *ansiblemocks.Store) *ansible.Handler {
+	return ansible.NewHandler(store, validator.New(), zap.NewNop(), problem.New())
+}
+
+func newPartitionRequest(method, partitionName string, body []byte) *http.Request {
+	var r *http.Request
+	if body == nil {
+		r = httptest.NewRequest(method, "/api/partitions/"+partitionName+"/allowedGroups", nil)
+	} else {
+		r = httptest.NewRequest(method, "/api/partitions/"+partitionName+"/allowedGroups", bytes.NewReader(body))
+	}
+	r.SetPathValue("partition_name", partitionName)
+	return r
+}
 
 func TestHandlerAddNodes(t *testing.T) {
 	testCases := []struct {
@@ -77,6 +94,126 @@ func TestHandlerAddNodes(t *testing.T) {
 					assert.Equal(t, "provisioning", server.Status)
 				}
 			}
+		})
+	}
+}
+
+func TestHandler_GetPartitionAllowedGroups(t *testing.T) {
+	groupID := uuid.New()
+
+	testCases := []struct {
+		name           string
+		setupMock      func(store *ansiblemocks.Store)
+		expectedStatus int
+		expectedGroups int
+	}{
+		{
+			name: "returns the allowed groups",
+			setupMock: func(store *ansiblemocks.Store) {
+				store.On("ListPartitionAllowedGroups", mock.Anything, "gpu").Return(
+					[]ansible.PartitionAllowedGroupDetail{{GroupID: groupID, Title: "CS Lab", LdapCN: "cs-lab"}}, nil,
+				)
+			},
+			expectedStatus: http.StatusOK,
+			expectedGroups: 1,
+		},
+		{
+			name: "unrestricted partition returns an empty list",
+			setupMock: func(store *ansiblemocks.Store) {
+				store.On("ListPartitionAllowedGroups", mock.Anything, "gpu").Return([]ansible.PartitionAllowedGroupDetail{}, nil)
+			},
+			expectedStatus: http.StatusOK,
+			expectedGroups: 0,
+		},
+		{
+			name: "unknown partition",
+			setupMock: func(store *ansiblemocks.Store) {
+				store.On("ListPartitionAllowedGroups", mock.Anything, "gpu").Return(
+					nil, handlerutil.NewNotFoundError("partitions", "name", "gpu", ""),
+				)
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := ansiblemocks.NewStore(t)
+			tc.setupMock(store)
+
+			w := httptest.NewRecorder()
+			newTestHandler(store).GetPartitionAllowedGroups(w, newPartitionRequest(http.MethodGet, "gpu", nil))
+
+			assert.Equal(t, tc.expectedStatus, w.Code)
+			if tc.expectedStatus == http.StatusOK {
+				var got []ansible.PartitionAllowedGroupResponse
+				assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+				assert.Len(t, got, tc.expectedGroups)
+			}
+		})
+	}
+}
+
+func TestHandler_UpdatePartitionAllowedGroups(t *testing.T) {
+	groupID := uuid.New()
+
+	testCases := []struct {
+		name           string
+		body           string
+		setupMock      func(store *ansiblemocks.Store)
+		expectedStatus int
+	}{
+		{
+			name: "assigns groups to a partition",
+			body: `{"groupIds":["` + groupID.String() + `"]}`,
+			setupMock: func(store *ansiblemocks.Store) {
+				store.On("SetPartitionAllowedGroups", mock.Anything, "gpu", []uuid.UUID{groupID}).Return(nil)
+			},
+			expectedStatus: http.StatusNoContent,
+		},
+		{
+			name: "empty list re-opens the partition",
+			body: `{"groupIds":[]}`,
+			setupMock: func(store *ansiblemocks.Store) {
+				store.On("SetPartitionAllowedGroups", mock.Anything, "gpu", []uuid.UUID{}).Return(nil)
+			},
+			expectedStatus: http.StatusNoContent,
+		},
+		{
+			name:           "non-uuid group id is rejected before reaching the store",
+			body:           `{"groupIds":["not-a-uuid"]}`,
+			setupMock:      func(store *ansiblemocks.Store) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "unknown partition",
+			body: `{"groupIds":["` + groupID.String() + `"]}`,
+			setupMock: func(store *ansiblemocks.Store) {
+				store.On("SetPartitionAllowedGroups", mock.Anything, "gpu", []uuid.UUID{groupID}).Return(
+					handlerutil.NewNotFoundError("partitions", "name", "gpu", ""),
+				)
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name: "store failure",
+			body: `{"groupIds":["` + groupID.String() + `"]}`,
+			setupMock: func(store *ansiblemocks.Store) {
+				store.On("SetPartitionAllowedGroups", mock.Anything, "gpu", []uuid.UUID{groupID}).Return(errors.New("db error"))
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := ansiblemocks.NewStore(t)
+			tc.setupMock(store)
+
+			w := httptest.NewRecorder()
+			newTestHandler(store).UpdatePartitionAllowedGroups(w, newPartitionRequest(http.MethodPut, "gpu", []byte(tc.body)))
+
+			assert.Equal(t, tc.expectedStatus, w.Code)
 		})
 	}
 }

--- a/internal/ansible/handler_test.go
+++ b/internal/ansible/handler_test.go
@@ -1,89 +1,82 @@
-package ansible
+package ansible_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"clustron-backend/internal"
-
+	"github.com/NYCU-SDC/summer/pkg/problem"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
+
+	"clustron-backend/internal/ansible"
+	ansiblemocks "clustron-backend/internal/ansible/mocks"
 )
 
-type addNodesStore struct {
-	Store
-	gotParams []CreateParams
-}
-
-func (s *addNodesStore) AddNodes(_ context.Context, params []CreateParams) ([]Server, error) {
-	s.gotParams = params
-	servers := make([]Server, len(params))
-	for i, param := range params {
-		servers[i] = Server{
-			ID:            uuid.New(),
-			AnsibleName:   param.AnsibleName,
-			IpAddress:     param.IpAddress,
-			SshConfigHost: param.SshConfigHost,
-			SshUser:       param.SshUser,
-			AnsibleRole:   param.AnsibleRole,
-			Status:        "provisioning",
-		}
-	}
-	return servers, nil
-}
-
 func TestHandlerAddNodes(t *testing.T) {
-	store := &addNodesStore{}
-	handler := NewHandler(store, validator.New(), zap.NewNop(), internal.NewProblemWriter())
-	body := []byte(`{
-		"servers": [
-			{
-				"ansible_name": "compute-01",
-				"ip_address": "192.0.2.1",
-				"ssh_user": "ubuntu",
-				"ansible_role": "compute_nodes"
+	testCases := []struct {
+		name           string
+		body           string
+		setupMock      func(store *ansiblemocks.Store)
+		expectedStatus int
+		expectedCount  int
+	}{
+		{
+			name: "creates two servers",
+			body: `{
+				"servers": [
+					{
+						"ansible_name": "compute-01",
+						"ip_address": "192.0.2.1",
+						"ssh_user": "ubuntu",
+						"ansible_role": "compute_nodes"
+					},
+					{
+						"ansible_name": "compute-02",
+						"ssh_config_host": "compute-02",
+						"private_ip": "10.0.0.2",
+						"ansible_role": "compute_nodes"
+					}
+				]
+			}`,
+			setupMock: func(store *ansiblemocks.Store) {
+				store.On("AddNodes", mock.Anything, mock.MatchedBy(func(params []ansible.CreateParams) bool {
+					return len(params) == 2
+				})).Return([]ansible.Server{
+					{ID: uuid.New(), AnsibleName: "compute-01", Status: "provisioning"},
+					{ID: uuid.New(), AnsibleName: "compute-02", Status: "provisioning"},
+				}, nil)
 			},
-			{
-				"ansible_name": "compute-02",
-				"ssh_config_host": "compute-02",
-				"private_ip": "10.0.0.2",
-				"ansible_role": "compute_nodes"
+			expectedStatus: http.StatusCreated,
+			expectedCount:  2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := ansiblemocks.NewStore(t)
+			tc.setupMock(store)
+
+			h := ansible.NewHandler(store, validator.New(), zap.NewNop(), problem.New())
+			req := httptest.NewRequest(http.MethodPost, "/api/servers/batch", bytes.NewReader([]byte(tc.body)))
+			w := httptest.NewRecorder()
+
+			h.AddNodes(w, req)
+
+			assert.Equal(t, tc.expectedStatus, w.Code)
+			if tc.expectedStatus == http.StatusCreated {
+				var response ansible.AddNodesResponse
+				assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+				assert.Len(t, response.Servers, tc.expectedCount)
+				for _, server := range response.Servers {
+					assert.Equal(t, "provisioning", server.Status)
+				}
 			}
-		]
-	}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/servers/batch", bytes.NewReader(body))
-	recorder := httptest.NewRecorder()
-
-	handler.AddNodes(recorder, req)
-
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusCreated, recorder.Body.String())
-	}
-	if len(store.gotParams) != 2 {
-		t.Fatalf("AddNodes params length = %d, want 2", len(store.gotParams))
-	}
-	if !store.gotParams[0].IpAddress.Valid || store.gotParams[0].IpAddress.String != "192.0.2.1" {
-		t.Errorf("first server IP = %#v, want 192.0.2.1", store.gotParams[0].IpAddress)
-	}
-	if !store.gotParams[1].SshConfigHost.Valid || store.gotParams[1].SshConfigHost.String != "compute-02" {
-		t.Errorf("second server SSH config host = %#v, want compute-02", store.gotParams[1].SshConfigHost)
-	}
-
-	var response AddNodesResponse
-	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if len(response.Servers) != 2 {
-		t.Fatalf("response servers length = %d, want 2", len(response.Servers))
-	}
-	for _, server := range response.Servers {
-		if server.Status != "provisioning" {
-			t.Errorf("server %q status = %q, want provisioning", server.AnsibleName, server.Status)
-		}
+		})
 	}
 }

--- a/internal/ansible/policy.csv
+++ b/internal/ansible/policy.csv
@@ -8,3 +8,5 @@ p, admin, /api/servers/:server_id/reset, POST
 p, admin, /api/servers/:server_id/role, PATCH
 p, admin, /api/servers/:server_id/allowedLoginGroups, GET
 p, admin, /api/servers/:server_id/allowedLoginGroups, PUT
+p, admin, /api/partitions/:partition_name/allowedGroups, GET
+p, admin, /api/partitions/:partition_name/allowedGroups, PUT

--- a/internal/ansible/queries.sql
+++ b/internal/ansible/queries.sql
@@ -75,3 +75,32 @@ SELECT EXISTS (SELECT 1 FROM allowed_login_groups WHERE server_id = $1) AS exist
 
 -- name: ExistBaseLdapGroup :one
 SELECT EXISTS (SELECT 1 FROM ldap_groups WHERE group_id = $1 AND type = 'BASE') AS exists;
+
+-- name: ListDistinctPartitionNames :many
+SELECT DISTINCT slurm_partition
+FROM servers
+WHERE ansible_role = 'compute_nodes'
+ORDER BY slurm_partition;
+
+-- name: ListPartitionAllowedGroups :many
+SELECT pag.group_id, g.title, lg.ldap_cn
+FROM partition_allowed_groups pag
+JOIN groups g ON g.id = pag.group_id
+JOIN ldap_groups lg ON lg.group_id = pag.group_id AND lg.type = 'BASE'
+WHERE pag.partition_name = $1
+ORDER BY g.title;
+
+-- name: ListAllPartitionAllowedAccounts :many
+SELECT pag.partition_name, lg.ldap_cn
+FROM partition_allowed_groups pag
+JOIN ldap_groups lg ON lg.group_id = pag.group_id AND lg.type = 'BASE'
+WHERE lg.ldap_cn IS NOT NULL
+ORDER BY pag.partition_name, lg.ldap_cn;
+
+-- name: ClearPartitionAllowedGroups :exec
+DELETE FROM partition_allowed_groups WHERE partition_name = $1;
+
+-- name: AddPartitionAllowedGroup :exec
+INSERT INTO partition_allowed_groups (partition_name, group_id)
+VALUES ($1, $2)
+ON CONFLICT DO NOTHING;

--- a/internal/ansible/schema.sql
+++ b/internal/ansible/schema.sql
@@ -57,3 +57,12 @@ CREATE TABLE IF NOT EXISTS allowed_login_groups
 
     PRIMARY KEY (server_id, group_id)
 );
+
+-- rendered into slurm.conf as PartitionName=... AllowAccounts=...
+CREATE TABLE IF NOT EXISTS partition_allowed_groups
+(
+    partition_name VARCHAR(255) NOT NULL,
+    group_id       UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+
+    PRIMARY KEY (partition_name, group_id)
+);

--- a/internal/ansible/service.go
+++ b/internal/ansible/service.go
@@ -43,7 +43,12 @@ const (
 	headNodeRole            = "head_nodes"
 	computeNodeRole         = "compute_nodes"
 	sssdTag                 = "sssd"
+	slurmConfigTag          = "slurm_config"
 	computePrerequisiteTags = "nfs_exports,slurm_config"
+
+	// defaultPartitionName is the partition a compute node falls into when it has no
+	// slurm_partition set, matching the default applied by slurm.conf.j2.
+	defaultPartitionName = "normal"
 )
 
 type Service struct {
@@ -741,6 +746,159 @@ func validateAllowedLoginGroupRoleChange(role string, hasAllowedLoginGroups bool
 	return nil
 }
 
+// ListPartitionAllowedGroups returns the Clustron groups allowed to submit jobs to a Slurm
+// partition (rendered into that partition's slurm.conf AllowAccounts list).
+func (s *Service) ListPartitionAllowedGroups(ctx context.Context, partitionName string) ([]PartitionAllowedGroupDetail, error) {
+	traceCtx, span := s.tracer.Start(ctx, "ListPartitionAllowedGroups")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, s.logger)
+
+	if err := s.ensurePartitionExists(traceCtx, partitionName); err != nil {
+		return nil, err
+	}
+
+	rows, err := s.queries.ListPartitionAllowedGroups(traceCtx, partitionName)
+	if err != nil {
+		return nil, databaseutil.WrapDBError(err, logger, "list partition allowed groups")
+	}
+
+	result := make([]PartitionAllowedGroupDetail, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, PartitionAllowedGroupDetail{
+			GroupID: row.GroupID,
+			Title:   row.Title,
+			LdapCN:  row.LdapCn.String,
+		})
+	}
+	return result, nil
+}
+
+// SetPartitionAllowedGroups replaces a partition's allowed-group list with the given groups,
+// then re-renders slurm.conf in the background. Each group must already have a BASE LDAP
+// group, since its ldap_cn is the name of the group's top-level Slurm account. An empty list
+// leaves the partition unrestricted.
+func (s *Service) SetPartitionAllowedGroups(ctx context.Context, partitionName string, groupIDs []uuid.UUID) error {
+	traceCtx, span := s.tracer.Start(ctx, "SetPartitionAllowedGroups")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, s.logger)
+
+	if err := s.ensurePartitionExists(traceCtx, partitionName); err != nil {
+		return err
+	}
+
+	for _, id := range groupIDs {
+		exist, err := s.queries.ExistBaseLdapGroup(traceCtx, id)
+		if err != nil {
+			return databaseutil.WrapDBError(err, logger, "check base ldap group exists")
+		}
+		if !exist {
+			return databaseutil.WrapDBErrorWithKeyValue(pgx.ErrNoRows, "ldap_groups", "group_id", id.String(), logger, "find base ldap group for partition allowed group")
+		}
+	}
+
+	tx, err := s.db.Begin(traceCtx)
+	if err != nil {
+		return databaseutil.WrapDBError(err, logger, "begin tx for set partition allowed groups")
+	}
+	defer func() { _ = tx.Rollback(traceCtx) }()
+
+	qtx := s.queries.WithTx(tx)
+	if err = qtx.ClearPartitionAllowedGroups(traceCtx, partitionName); err != nil {
+		return databaseutil.WrapDBError(err, logger, "clear partition allowed groups")
+	}
+	for _, id := range groupIDs {
+		if err = qtx.AddPartitionAllowedGroup(traceCtx, AddPartitionAllowedGroupParams{
+			PartitionName: partitionName,
+			GroupID:       id,
+		}); err != nil {
+			return mapPartitionAllowedGroupError(err, id, logger)
+		}
+	}
+	if err = tx.Commit(traceCtx); err != nil {
+		return databaseutil.WrapDBError(err, logger, "commit partition allowed groups")
+	}
+
+	bgCtx := context.WithoutCancel(traceCtx)
+	bgCtx, cancel := context.WithTimeout(bgCtx, time.Hour)
+
+	go func() {
+		defer cancel()
+		s.runSlurmConfigInBackground(bgCtx)
+	}()
+
+	return nil
+}
+
+// ensurePartitionExists rejects partition names that slurm.conf will not contain. Partitions
+// are not an entity: they exist only as the slurm_partition label on compute nodes.
+func (s *Service) ensurePartitionExists(ctx context.Context, partitionName string) error {
+	logger := logutil.WithContext(ctx, s.logger)
+
+	rows, err := s.queries.ListDistinctPartitionNames(ctx)
+	if err != nil {
+		return databaseutil.WrapDBError(err, logger, "list distinct partition names")
+	}
+
+	return validatePartitionExists(partitionName, knownPartitionNames(rows))
+}
+
+// knownPartitionNames maps the distinct slurm_partition values of the compute nodes onto the
+// partitions slurm.conf.j2 will emit: unset values collapse into defaultPartitionName.
+func knownPartitionNames(rows []pgtype.Text) []string {
+	names := make([]string, 0, len(rows))
+	hasUnset := false
+	for _, row := range rows {
+		if row.Valid && row.String != "" {
+			names = append(names, row.String)
+			continue
+		}
+		hasUnset = true
+	}
+	if hasUnset {
+		names = append(names, defaultPartitionName)
+	}
+	return names
+}
+
+func validatePartitionExists(partitionName string, known []string) error {
+	for _, name := range known {
+		if name == partitionName {
+			return nil
+		}
+	}
+	return handlerutil.NewNotFoundError("partitions", "name", partitionName, "")
+}
+
+func mapPartitionAllowedGroupError(err error, groupID uuid.UUID, logger *zap.Logger) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == databaseutil.PGErrForeignKeyViolation {
+		return handlerutil.NewNotFoundError("groups", "id", groupID.String(), "")
+	}
+	return databaseutil.WrapDBError(err, logger, "add partition allowed group")
+}
+
+// runSlurmConfigInBackground re-renders the inventory and reapplies only the head node's
+// Slurm configuration. Unlike runAnsibleInBackground it provisions nothing and never touches
+// server status, because a partition access change is a config edit, not a deployment.
+func (s *Service) runSlurmConfigInBackground(ctx context.Context) {
+	s.ansibleMu.Lock()
+	defer s.ansibleMu.Unlock()
+
+	logger := logutil.WithContext(ctx, s.logger)
+
+	if err := s.generateInventory(ctx); err != nil {
+		logger.Error("fail to generate inventory for slurm config update", zap.Error(err))
+		return
+	}
+
+	logger.Info("[background] re-rendering slurm.conf")
+	if err := s.runUpdateRoles(ctx, os.Stdout, slurmConfigTag); err != nil {
+		logger.Error("fail to re-render slurm.conf", zap.Error(err))
+		return
+	}
+	logger.Info("slurm.conf re-rendered")
+}
+
 func (s *Service) generateInventory(ctx context.Context) error {
 	servers, err := s.queries.ListAll(ctx)
 	if err != nil {
@@ -817,6 +975,24 @@ func (s *Service) generateInventory(ctx context.Context) error {
 		hostVars.LDAPSimpleAllowGroups = strings.Join(cns, ", ")
 
 		inventory.All.Children[roleGroup].Hosts[srv.AnsibleName] = hostVars
+	}
+
+	// Partition access is a property of the partition, not of any single node, so it goes in
+	// the play-wide vars. slurm.conf.j2 turns each entry into AllowAccounts= on that
+	// partition; partitions absent here stay unrestricted.
+	allowedRows, err := s.queries.ListAllPartitionAllowedAccounts(ctx)
+	if err != nil {
+		return databaseutil.WrapDBError(err, s.logger, "list partition allowed accounts")
+	}
+	allowedAccounts := make(map[string][]string)
+	for _, row := range allowedRows {
+		if !row.LdapCn.Valid || row.LdapCn.String == "" {
+			continue
+		}
+		allowedAccounts[row.PartitionName] = append(allowedAccounts[row.PartitionName], row.LdapCn.String)
+	}
+	if len(allowedAccounts) > 0 {
+		inventory.All.Vars["slurm_partition_allowed_accounts"] = allowedAccounts
 	}
 
 	yamlData, err := yaml.Marshal(&inventory)

--- a/internal/ansible/service_test.go
+++ b/internal/ansible/service_test.go
@@ -1,11 +1,12 @@
 package ansible
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"clustron-backend/internal"
-	"fmt"
 
 	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
 	"github.com/go-playground/validator/v10"
@@ -462,4 +463,105 @@ func TestParseAnsibleRecap(t *testing.T) {
 	assert.True(t, got["compute-01"])
 	assert.False(t, got["compute-02"])
 	assert.False(t, got["compute-03"])
+}
+
+func TestKnownPartitionNames(t *testing.T) {
+	tests := []struct {
+		name string
+		rows []pgtype.Text
+		want []string
+	}{
+		{name: "no compute nodes", rows: nil, want: []string{}},
+		{
+			name: "named partitions only",
+			rows: []pgtype.Text{{String: "gpu", Valid: true}, {String: "normal", Valid: true}},
+			want: []string{"gpu", "normal"},
+		},
+		{
+			name: "unset partition collapses into the template default",
+			rows: []pgtype.Text{{Valid: false}, {String: "gpu", Valid: true}},
+			want: []string{"gpu", defaultPartitionName},
+		},
+		{
+			name: "empty string is treated as unset",
+			rows: []pgtype.Text{{String: "", Valid: true}},
+			want: []string{defaultPartitionName},
+		},
+		{
+			name: "unset and an explicit normal do not duplicate the entry meaningfully",
+			rows: []pgtype.Text{{Valid: false}, {String: "normal", Valid: true}},
+			want: []string{"normal", defaultPartitionName},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := knownPartitionNames(tt.rows)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidatePartitionExists(t *testing.T) {
+	known := []string{"gpu", "normal"}
+	tests := []struct {
+		name          string
+		partitionName string
+		wantErr       bool
+	}{
+		{name: "known partition", partitionName: "gpu"},
+		{name: "default partition", partitionName: "normal"},
+		{name: "unknown partition", partitionName: "cpu", wantErr: true},
+		{name: "empty name", partitionName: "", wantErr: true},
+		{name: "case mismatch", partitionName: "GPU", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePartitionExists(tt.partitionName, known)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, handlerutil.ErrNotFound)
+				assert.Contains(t, err.Error(), tt.partitionName)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMapPartitionAllowedGroupError(t *testing.T) {
+	groupID := uuid.New()
+
+	err := mapPartitionAllowedGroupError(&pgconn.PgError{Code: "23503", ConstraintName: "partition_allowed_groups_group_id_fkey"}, groupID, zap.NewNop())
+	assert.ErrorIs(t, err, handlerutil.ErrNotFound)
+	assert.Contains(t, err.Error(), groupID.String())
+
+	other := mapPartitionAllowedGroupError(errors.New("connection reset"), groupID, zap.NewNop())
+	assert.NotErrorIs(t, other, handlerutil.ErrNotFound)
+}
+
+func TestUpdatePartitionAllowedGroupsRequestValidation(t *testing.T) {
+	v := validator.New()
+
+	tests := []struct {
+		name    string
+		req     UpdatePartitionAllowedGroupsRequest
+		wantErr bool
+	}{
+		{name: "group ids", req: UpdatePartitionAllowedGroupsRequest{GroupIDs: []string{uuid.NewString()}}},
+		{name: "empty list re-opens the partition", req: UpdatePartitionAllowedGroupsRequest{GroupIDs: []string{}}},
+		{name: "omitted list re-opens the partition", req: UpdatePartitionAllowedGroupsRequest{}},
+		{name: "non-uuid group id", req: UpdatePartitionAllowedGroupsRequest{GroupIDs: []string{"not-a-uuid"}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Struct(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/ansible/service_test.go
+++ b/internal/ansible/service_test.go
@@ -1,18 +1,19 @@
 package ansible
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
 	"clustron-backend/internal"
+	"fmt"
 
 	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
@@ -38,9 +39,7 @@ func TestDuplicateServerField(t *testing.T) {
 		t.Run(tt.constraint, func(t *testing.T) {
 			field, value := duplicateServerField(tt.constraint, params)
 			detail := fmt.Sprintf(`%s %q`, field, value)
-			if detail != tt.wantDetail {
-				t.Fatalf("duplicateServerField() detail = %q, want %q", detail, tt.wantDetail)
-			}
+			assert.Equal(t, tt.wantDetail, detail)
 		})
 	}
 }
@@ -60,12 +59,8 @@ func TestMapAllowedLoginGroupError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := mapAllowedLoginGroupError(&pgconn.PgError{Code: "23503", ConstraintName: tt.constraint}, serverID, groupID, zap.NewNop())
-			if !errors.Is(err, handlerutil.ErrNotFound) {
-				t.Fatalf("mapAllowedLoginGroupError() error = %v, want ErrNotFound", err)
-			}
-			if !strings.Contains(err.Error(), tt.wantValue) {
-				t.Fatalf("mapAllowedLoginGroupError() error = %q, want value %q", err, tt.wantValue)
-			}
+			assert.ErrorIs(t, err, handlerutil.ErrNotFound)
+			assert.Contains(t, err.Error(), tt.wantValue)
 		})
 	}
 }
@@ -105,8 +100,10 @@ func TestAddNodeRequestAnsibleNameValidation(t *testing.T) {
 			}
 
 			err := validate.Struct(req)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("validator.Struct() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -142,8 +139,10 @@ func TestAddNodeRequestSshUserValidation(t *testing.T) {
 			}
 
 			err := validate.Struct(req)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("validator.Struct() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -200,8 +199,10 @@ func TestAddNodeRequestIPValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validate.Struct(tt.req)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("validator.Struct() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -224,9 +225,7 @@ func TestServerRequestStringValidation(t *testing.T) {
 	validate := validator.New()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validate.Struct(tt.req); err == nil {
-				t.Fatal("validator.Struct() error = nil, want validation error")
-			}
+			assert.Error(t, validate.Struct(tt.req))
 		})
 	}
 }
@@ -258,8 +257,10 @@ func TestAddNodeRequestHardwareValidation(t *testing.T) {
 			req.MemoryMb = tt.memoryMB
 
 			err := validate.Struct(req)
-			if (err != nil) != tt.wantError {
-				t.Fatalf("validator.Struct() error = %v, wantError %v", err, tt.wantError)
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -268,13 +269,9 @@ func TestAddNodeRequestHardwareValidation(t *testing.T) {
 func TestUpdateRoleRequestValidation(t *testing.T) {
 	validate := validator.New()
 	for _, role := range []string{headNodeRole, computeNodeRole} {
-		if err := validate.Struct(UpdateRoleRequest{AnsibleRole: role}); err != nil {
-			t.Errorf("validator.Struct(%q) error = %v", role, err)
-		}
+		assert.NoError(t, validate.Struct(UpdateRoleRequest{AnsibleRole: role}))
 	}
-	if err := validate.Struct(UpdateRoleRequest{AnsibleRole: "worker"}); err == nil {
-		t.Fatal("validator.Struct(unknown role) error = nil, want validation error")
-	}
+	assert.Error(t, validate.Struct(UpdateRoleRequest{AnsibleRole: "worker"}))
 }
 
 func TestAddNodesRequestValidation(t *testing.T) {
@@ -299,8 +296,10 @@ func TestAddNodesRequestValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validate.Struct(tt.req)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("validator.Struct() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -334,9 +333,7 @@ func TestToCreateParams(t *testing.T) {
 		MemoryMb:       pgtype.Int4{Int32: memoryMB, Valid: true},
 	}
 
-	if got != want {
-		t.Fatalf("toCreateParams() = %#v, want %#v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestHostVarsAnsibleUserYAML(t *testing.T) {
@@ -352,14 +349,8 @@ func TestHostVarsAnsibleUserYAML(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			data, err := yaml.Marshal(HostVars{UserName: tt.ansibleUser})
-			if err != nil {
-				t.Fatalf("yaml.Marshal() error = %v", err)
-			}
-
-			hasAnsibleUser := strings.Contains(string(data), "ansible_user:")
-			if hasAnsibleUser != tt.wantAnsibleUser {
-				t.Fatalf("yaml.Marshal() = %q, want ansible_user field %v", data, tt.wantAnsibleUser)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAnsibleUser, strings.Contains(string(data), "ansible_user:"))
 		})
 	}
 }
@@ -380,9 +371,7 @@ func TestValidateAllowedLoginGroupTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateAllowedLoginGroupTarget(tt.role, tt.groupIDs)
-			if !errors.Is(err, tt.wantErr) {
-				t.Fatalf("validateAllowedLoginGroupTarget() error = %v, want %v", err, tt.wantErr)
-			}
+			assert.ErrorIs(t, err, tt.wantErr)
 		})
 	}
 }
@@ -402,9 +391,7 @@ func TestValidateAllowedLoginGroupRoleChange(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateAllowedLoginGroupRoleChange(tt.role, tt.hasAllowedLoginGroups)
-			if !errors.Is(err, tt.wantErr) {
-				t.Fatalf("validateAllowedLoginGroupRoleChange() error = %v, want %v", err, tt.wantErr)
-			}
+			assert.ErrorIs(t, err, tt.wantErr)
 		})
 	}
 }
@@ -422,11 +409,7 @@ func TestParseAnsibleError(t *testing.T) {
 				"fatal: [compute-01]: FAILED! => {\"msg\": \"package not found\"}\n" +
 				"PLAY RECAP ****\n" +
 				"compute-01 : ok=1 changed=0 unreachable=0 failed=1\n",
-			want: []string{
-				"Stage: Install package",
-				"fatal: [compute-01]: FAILED!",
-				"PLAY RECAP:",
-			},
+			want:       []string{"Stage: Install package", "fatal: [compute-01]: FAILED!", "PLAY RECAP:"},
 			wantAbsent: []string{"Output tail:"},
 		},
 		{
@@ -437,29 +420,19 @@ func TestParseAnsibleError(t *testing.T) {
 				"compute-01 : ok=0 changed=0 unreachable=0 failed=1\n" +
 				"TASKS RECAP ****\n" +
 				"Validate configuration ----------------------------- 0.14s\n",
-			want: []string{
-				"Stage: Validate configuration",
-				"[ERROR]: Task failed: configuration is invalid",
-				"compute-01 : ok=0 changed=0 unreachable=0 failed=1",
-			},
+			want:       []string{"Stage: Validate configuration", "[ERROR]: Task failed: configuration is invalid", "compute-01 : ok=0 changed=0 unreachable=0 failed=1"},
 			wantAbsent: []string{"Output tail:", "TASKS RECAP", "0.14s"},
 		},
 		{
 			name:   "unknown output falls back to raw tail",
 			output: "unexpected callback output\nconnection closed by remote host\n",
-			want: []string{
-				"Output tail:",
-				"unexpected callback output",
-				"connection closed by remote host",
-			},
+			want:   []string{"Output tail:", "unexpected callback output", "connection closed by remote host"},
 		},
 		{
-			name:   "raw tail is bounded",
-			output: "oldest line\n" + strings.Repeat("middle line\n", maxAnsibleErrorOutputLines-1) + "newest line",
-			want:   []string{"middle line", "newest line"},
-			wantAbsent: []string{
-				"oldest line",
-			},
+			name:       "raw tail is bounded",
+			output:     "oldest line\n" + strings.Repeat("middle line\n", maxAnsibleErrorOutputLines-1) + "newest line",
+			want:       []string{"middle line", "newest line"},
+			wantAbsent: []string{"oldest line"},
 		},
 	}
 
@@ -467,14 +440,10 @@ func TestParseAnsibleError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseAnsibleError(tt.output)
 			for _, want := range tt.want {
-				if !strings.Contains(got, want) {
-					t.Errorf("parseAnsibleError() = %q, want substring %q", got, want)
-				}
+				assert.Contains(t, got, want)
 			}
 			for _, unwanted := range tt.wantAbsent {
-				if strings.Contains(got, unwanted) {
-					t.Errorf("parseAnsibleError() = %q, unwanted substring %q", got, unwanted)
-				}
+				assert.NotContains(t, got, unwanted)
 			}
 		})
 	}
@@ -489,17 +458,8 @@ func TestParseAnsibleRecap(t *testing.T) {
 		"common : configure host -------------------------------- 1.00s\n"
 
 	got := parseAnsibleRecap(output)
-	want := map[string]bool{
-		"compute-01": true,
-		"compute-02": false,
-		"compute-03": false,
-	}
-	if len(got) != len(want) {
-		t.Fatalf("parseAnsibleRecap() = %#v, want %#v", got, want)
-	}
-	for host, wantSuccess := range want {
-		if got[host] != wantSuccess {
-			t.Errorf("parseAnsibleRecap()[%q] = %v, want %v", host, got[host], wantSuccess)
-		}
-	}
+	assert.Len(t, got, 3)
+	assert.True(t, got["compute-01"])
+	assert.False(t, got["compute-02"])
+	assert.False(t, got["compute-03"])
 }

--- a/internal/ansible/type.go
+++ b/internal/ansible/type.go
@@ -10,6 +10,14 @@ type AllowedLoginGroupDetail struct {
 	LdapCN  string
 }
 
+// PartitionAllowedGroupDetail is a Clustron group allowed to submit jobs to a Slurm
+// partition. Its BASE ldap_cn is rendered into that partition's AllowAccounts list.
+type PartitionAllowedGroupDetail struct {
+	GroupID uuid.UUID
+	Title   string
+	LdapCN  string
+}
+
 type InventoryFiles struct {
 	All ServerGroup `yaml:"all"`
 }

--- a/internal/database/migrations/20260818000000_create_partition_allowed_groups.down.sql
+++ b/internal/database/migrations/20260818000000_create_partition_allowed_groups.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS partition_allowed_groups;

--- a/internal/database/migrations/20260818000000_create_partition_allowed_groups.up.sql
+++ b/internal/database/migrations/20260818000000_create_partition_allowed_groups.up.sql
@@ -1,0 +1,14 @@
+-- Groups allowed to submit jobs to a Slurm partition. Rendered into slurm.conf as
+-- PartitionName=... AllowAccounts=<group base cn>,... A partition with no rows here is
+-- left unrestricted (Slurm's default AllowAccounts=ALL).
+--
+-- Keyed by partition name because partitions are not an entity: they exist only as the
+-- servers.slurm_partition label on each compute node, grouped into PartitionName lines by
+-- the slurm_controller ansible template.
+CREATE TABLE IF NOT EXISTS partition_allowed_groups
+(
+    partition_name VARCHAR(255) NOT NULL,
+    group_id       UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+
+    PRIMARY KEY (partition_name, group_id)
+);


### PR DESCRIPTION
### Type of changes

- Feature
- Refactor
- Test

### Purpose

Why: Admins need to restrict which groups can submit Slurm jobs to specific partitions (e.g. reserve a GPU partition for a research lab). Previously there was no mechanism — every group could access every partition.

What: Add partition_allowed_groups table and two admin-only REST endpoints (GET/PUT /api/partitions/{partition_name}/allowedGroups) that let admins assign Clustron groups to a partition. When set, the partition's AllowAccounts= in slurm.conf lists only those groups' LDAP account names. An empty list leaves the partition unrestricted.

How:
- New DB table partition_allowed_groups(partition_name, group_id) with migration
- sqlc queries for CRUD + a bulk query for inventory generation
- Service layer validates the partition exists (derived from compute nodes' slurm_partition label), checks each group has a BASE LDAP group, replaces the list in a transaction, then triggers a background slurm_config-only Ansible run (no full deploy)
- generateInventory injects slurm_partition_allowed_accounts into play-wide vars
- slurm.conf.j2 conditionally emits AllowAccounts= per partition
- Existing tests converted from hand-rolled stubs to testify + mockery mocks

### Additional Information

- Partition validation: Partitions are not a first-class entity — they're derived from the slurm_partition column on compute nodes. Nodes with no value collapse to "normal" (matching the Jinja2 template default).
- Background Ansible run: Uses slurmConfigTag only, so it re-renders slurm.conf on the head node without touching compute node provisioning. Holds ansibleMu to serialize with other Ansible operations.
- Empty list semantics: PUT with {"groupIds":[]} clears the restriction. The groupIds field intentionally omits the required validator tag so an empty array passes validation.
- Test coverage: Handler endpoints fully covered via mockery mocks (happy path, 404, 400, 500). Pure logic functions (knownPartitionNames, validatePartitionExists, mapPartitionAllowedGroupError) at 100%. Service-layer orchestration methods are DB-dependent and would need integration tests.